### PR TITLE
Use TemporalUnit enum values instead of numbers directly

### DIFF
--- a/contracts/Scheduler/BlockScheduler.sol
+++ b/contracts/Scheduler/BlockScheduler.sol
@@ -15,7 +15,7 @@ contract BlockScheduler is BaseScheduler {
      */
     function BlockScheduler(address _factoryAddress) public {
         // Default temporal unit is block number.
-        temporalUnit = RequestScheduleLib.TemporalUnit(1);
+        temporalUnit = RequestScheduleLib.TemporalUnit.Blocks;
 
         // Sets the factoryAddress variable found in SchedulerInterface contract.
         factoryAddress = _factoryAddress;

--- a/contracts/Scheduler/TimestampScheduler.sol
+++ b/contracts/Scheduler/TimestampScheduler.sol
@@ -15,7 +15,7 @@ contract TimestampScheduler is BaseScheduler {
      */
     function TimestampScheduler(address _factoryAddress) public {
         // Default temporal unit is timestamp.
-        temporalUnit = RequestScheduleLib.TemporalUnit(2);
+        temporalUnit = RequestScheduleLib.TemporalUnit.Timestamp;
 
         // Sets the factoryAddress variable found in SchedulerInterface contract.
         factoryAddress = _factoryAddress;


### PR DESCRIPTION
While studying the source code I found that BlockScheduler and TimestampScheduler are using numbers directly instead of using TemporalUnit enum members.
Not sure whether this was intentional or not, but as tests are still passing, here is a PR.
Feel free do reject it if there is a good reason for hardcoding the numbers directly.