### PR TITLE
Upgrade to 0.4.21

### DIFF
--- a/contracts/Interface/RequestFactoryInterface.sol
+++ b/contracts/Interface/RequestFactoryInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 contract RequestFactoryInterface {
 

--- a/contracts/Interface/RequestTrackerInterface.sol
+++ b/contracts/Interface/RequestTrackerInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 contract RequestTrackerInterface {
 

--- a/contracts/Interface/SchedulerInterface.sol
+++ b/contracts/Interface/SchedulerInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Library/RequestScheduleLib.sol";
 import "contracts/Library/SchedulerLib.sol";

--- a/contracts/Interface/TransactionRequestInterface.sol
+++ b/contracts/Interface/TransactionRequestInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 contract TransactionRequestInterface {
     

--- a/contracts/IterTools.sol
+++ b/contracts/IterTools.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /**
  * @title IterTools

--- a/contracts/Library/ClaimLib.sol
+++ b/contracts/Library/ClaimLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import 'contracts/zeppelin/SafeMath.sol';
 

--- a/contracts/Library/ExecutionLib.sol
+++ b/contracts/Library/ExecutionLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /**
  * @title ExecutionLib

--- a/contracts/Library/GroveLib.sol
+++ b/contracts/Library/GroveLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /// @title GroveLib - Library for queriable indexed ordered data.
 /// @author PiperMerriam - <pipermerriam@gmail.com>

--- a/contracts/Library/MathLib.sol
+++ b/contracts/Library/MathLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 library MathLib {
     uint constant INT_MAX = 57896044618658097711785492504343953926634992332820282019728792003956564819967;  // 2**255 - 1

--- a/contracts/Library/PaymentLib.sol
+++ b/contracts/Library/PaymentLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Library/ExecutionLib.sol";
 import "contracts/Library/MathLib.sol";

--- a/contracts/Library/RequestMetaLib.sol
+++ b/contracts/Library/RequestMetaLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /**
  * @title RequestMetaLib

--- a/contracts/Library/RequestScheduleLib.sol
+++ b/contracts/Library/RequestScheduleLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/zeppelin/SafeMath.sol";
 

--- a/contracts/Library/SchedulerLib.sol
+++ b/contracts/Library/SchedulerLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Interface/RequestFactoryInterface.sol";
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /// Truffle-specific contract (Not a part of the EAC)
 

--- a/contracts/RequestFactory.sol
+++ b/contracts/RequestFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Interface/RequestFactoryInterface.sol";
 import "contracts/Interface/RequestTrackerInterface.sol";

--- a/contracts/RequestTracker.sol
+++ b/contracts/RequestTracker.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Interface/RequestTrackerInterface.sol";
 import "contracts/Library/GroveLib.sol";

--- a/contracts/Scheduler/BaseScheduler.sol
+++ b/contracts/Scheduler/BaseScheduler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Interface/SchedulerInterface.sol";
 import "contracts/Library/RequestScheduleLib.sol";

--- a/contracts/Scheduler/BlockScheduler.sol
+++ b/contracts/Scheduler/BlockScheduler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Library/RequestScheduleLib.sol";
 import "contracts/Scheduler/BaseScheduler.sol";

--- a/contracts/Scheduler/TimestampScheduler.sol
+++ b/contracts/Scheduler/TimestampScheduler.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Library/RequestScheduleLib.sol";
 import "contracts/Scheduler/BaseScheduler.sol";

--- a/contracts/TransactionRequestCore.sol
+++ b/contracts/TransactionRequestCore.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import "contracts/Library/RequestLib.sol";
 import "contracts/Library/RequestScheduleLib.sol";

--- a/contracts/_examples/DelayedPayment.sol
+++ b/contracts/_examples/DelayedPayment.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 import 'contracts/Interface/SchedulerInterface.sol';
 

--- a/contracts/_test/SimpleToken.sol
+++ b/contracts/_test/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 /// Super simple token contract that moves funds into the owner account on creation and
 /// only exposes an API to be used for `test/proxy.js`

--- a/contracts/_test/TransactionRecorder.sol
+++ b/contracts/_test/TransactionRecorder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 contract TransactionRecorder {
     address owner;
@@ -14,7 +14,7 @@ contract TransactionRecorder {
     }
 
     function() payable {
-        lastCallGas = msg.gas;
+        lastCallGas = gasleft();
         lastCallData = msg.data;
         lastCaller = msg.sender;
         lastCallValue = msg.value;

--- a/contracts/zeppelin/SafeMath.sol
+++ b/contracts/zeppelin/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.19;
+pragma solidity ^0.4.21;
 
 
 /**

--- a/test/transaction-request/proxy.js
+++ b/test/transaction-request/proxy.js
@@ -76,7 +76,7 @@ contract("TransactionRequestCore proxy function", (accounts) => {
 
     // This is allowed since it is from scheduling accounts
     const tx = await txRequest.proxy(accounts[7], testData32)
-    expect(tx.receipt.status).to.equal(1)
+    expect(tx.receipt.status).to.equal('0x01')
   })
 
   it("does some fancy stuff with proxy", async () => {


### PR DESCRIPTION
This PR does 3 things:

* sets pragma to `^0.4.21` version - previously we set fixed compiler version, which also mean that we stick to given tooling version (for e.g `truffle` with 0.4.19 solc), upgrading to newer `truffle` breaks the compilation
* uses `emit` for events
* uses `gasleft()` instead of `msg.gas`
* explicitly cast `this` to `address` before accessing `this` members