### PR TITLE
Js and Solidity linters

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,11 @@
 extends: airbnb-base
+env:
+  node: true,
+  mocha: true
+globals:
+  artifacts: true,
+  web3: true,
+  contract: true
 rules:
   semi:
     - 0

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,0 @@
-useTabs: false
-tabWidth: 2
-semi: false
-trailingComma: es5
-arrowParens: always

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/zeppelin
+contracts/CloneFactory.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,17 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      4
+    ],
+    "security/no-block-members": [1, ["blockhash"]]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: node_js
 node_js:
   - '8.0.0'
 install:
+  - npm run lint
   - npm install -g truffle
   - truffle version
   - npm install -g ganache-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ language: node_js
 node_js:
   - '8.0.0'
 install:
-  - npm run lint
   - npm install -g truffle
   - truffle version
   - npm install -g ganache-cli
   - npm install
 script:
+  - npm run lint
+  - npm run solium
   - npm test
 before_script:
   - ganache-cli > /dev/null &

--- a/config/index.js
+++ b/config/index.js
@@ -1,107 +1,17 @@
-const _      = require("lodash"),
-    contract = require("truffle-contract"),
-    nconf    = require("nconf"),
-    path     = require("path"),
-    Web3     = require("web3"),
-    defaults = require("./defaults.json");
+// const _ = require("lodash")
+// const contract = require("truffle-contract")
+const path = require("path")
+const nconf = require("nconf")
+const Web3 = require("web3")
+const defaults = require("./defaults.json")
 
-const configPath = path.join(__dirname, '../config');
-nconf.env().argv();
-nconf.file({file: path.join(configPath, (nconf.get('NODE_ENV') || "dev") + ".json")});
-nconf.defaults(defaults);
+const configPath = path.join(__dirname, '../config')
+nconf.env().argv()
+nconf.file({ file: path.join(configPath, `${nconf.get('NODE_ENV') || "dev"}.json`) })
+nconf.defaults(defaults)
 
-const provider = new Web3.providers.HttpProvider(nconf.get("ethereum:provider"));
-const web3     = new Web3(provider);
+const provider = new Web3.providers.HttpProvider(nconf.get("ethereum:provider"))
+const web3 = new Web3(provider)
 
-// let properties       = ["contract_name", "abi", "unlinked_binary"];
-// let contractDefaults = {
-//     from: web3.eth.accounts[0],
-//     gas: 4712388,
-//     gasPrice: 100000000000
-// };
-
-// let MathLib = contract(_.pick(require("../build/contracts/MathLib.json"), properties));
-// MathLib.setProvider(provider);
-// MathLib.defaults(contractDefaults);
-
-// let GroveLib = contract(_.pick(require("../build/contracts/GroveLib.json"), properties));
-// GroveLib.setProvider(provider);
-// GroveLib.defaults(contractDefaults);
-
-// let IterTools = contract(_.pick(require("../build/contracts/IterTools.json"), properties));
-// IterTools.setProvider(provider);
-// IterTools.defaults(contractDefaults);
-
-// let ExecutionLib = contract(_.pick(require("../build/contracts/ExecutionLib.json"), properties));
-// ExecutionLib.setProvider(provider);
-// ExecutionLib.defaults(contractDefaults);
-
-// let RequestMetaLib = contract(_.pick(require("../build/contracts/RequestMetaLib.json"), properties));
-// RequestMetaLib.setProvider(provider);
-// RequestMetaLib.defaults(contractDefaults);
-
-// let ClaimLib = contract(_.pick(require("../build/contracts/ClaimLib.json"), properties));
-// ClaimLib.setProvider(provider);
-// ClaimLib.defaults(contractDefaults);
-
-// let PaymentLib = contract(_.pick(require("../build/contracts/PaymentLib.json"), properties));
-// PaymentLib.setProvider(provider);
-// PaymentLib.defaults(contractDefaults);
-
-// let RequestScheduleLib = contract(_.pick(require("../build/contracts/RequestScheduleLib.json"), properties));
-// RequestScheduleLib.setProvider(provider);
-// RequestScheduleLib.defaults(contractDefaults);
-
-// let RequestLib = contract(_.pick(require("../build/contracts/RequestLib.json"), properties));
-// RequestLib.setProvider(provider);
-// RequestLib.defaults(contractDefaults);
-
-// let SchedulerLib = contract(_.pick(require("../build/contracts/SchedulerLib.json"), properties));
-// SchedulerLib.setProvider(provider);
-// SchedulerLib.defaults(contractDefaults);
-
-// let BaseScheduler = contract(_.pick(require("../build/contracts/BaseScheduler.json"), properties));
-// BaseScheduler.setProvider(provider);
-// BaseScheduler.defaults(contractDefaults);
-
-// let BlockScheduler = contract(_.pick(require("../build/contracts/BlockScheduler.json"), properties));
-// BlockScheduler.setProvider(provider);
-// BlockScheduler.defaults(contractDefaults);
-
-// let TimestampScheduler = contract(_.pick(require("../build/contracts/TimestampScheduler.json"), properties));
-// TimestampScheduler.setProvider(provider);
-// TimestampScheduler.defaults(contractDefaults);
-
-// let RequestTracker = contract(_.pick(require("../build/contracts/RequestTracker.json"), properties));
-// RequestTracker.setProvider(provider);
-// RequestTracker.defaults(contractDefaults);
-
-// let TransactionRequest = contract(_.pick(require("../build/contracts/TransactionRequest.json"), properties));
-// TransactionRequest.setProvider(provider);
-// TransactionRequest.defaults(contractDefaults);
-
-// let RequestFactory = contract(_.pick(require("../build/contracts/RequestFactory.json"), properties));
-// RequestFactory.setProvider(provider);
-// RequestFactory.defaults(contractDefaults);
-
-module.exports      = nconf;
-module.exports.web3 = web3;
-
-// module.exports.contracts = {
-// MathLib: MathLib,
-// GroveLib: GroveLib,
-// IterTools: IterTools,
-// ExecutionLib: ExecutionLib,
-// RequestMetaLib: RequestMetaLib,
-// ClaimLib: ClaimLib,
-// PaymentLib: PaymentLib,
-// RequestScheduleLib: RequestScheduleLib,
-// RequestLib: RequestLib,
-// SchedulerLib: SchedulerLib,
-// BaseScheduler: BaseScheduler,
-// BlockScheduler: BlockScheduler,
-// TimestampScheduler: TimestampScheduler,
-// RequestTracker: RequestTracker,
-// TransactionRequest: TransactionRequest,
-// RequestFactory: RequestFactory
-// };
+module.exports = nconf
+module.exports.web3 = web3

--- a/contracts/Interface/RequestFactoryInterface.sol
+++ b/contracts/Interface/RequestFactoryInterface.sol
@@ -1,25 +1,10 @@
 pragma solidity ^0.4.21;
 
 contract RequestFactoryInterface {
-
     event RequestCreated(address request, address indexed owner, int indexed bucket, uint[12] params);
 
-    function createRequest(address[3] addressArgs,
-                           uint[12] uintArgs,
-                           bytes callData)
-        public payable returns (address);
-
-    function createValidatedRequest(address[3] addressArgs,
-                                    uint[12] uintArgs,
-                                    bytes callData) 
-        public payable returns (address);
-
-    function validateRequestParams(address[3] addressArgs,
-                                   uint[12] uintArgs,
-                                   bytes callData,
-                                   uint endowment) 
-        public view returns (bool[6]);
-
-    function isKnownRequest(address _address)
-        public view returns (bool);
+    function createRequest(address[3] addressArgs, uint[12] uintArgs, bytes callData) public payable returns (address);
+    function createValidatedRequest(address[3] addressArgs, uint[12] uintArgs, bytes callData) public payable returns (address);
+    function validateRequestParams(address[3] addressArgs, uint[12] uintArgs, bytes callData, uint endowment) public view returns (bool[6]);
+    function isKnownRequest(address _address) public view returns (bool);
 }

--- a/contracts/Interface/SchedulerInterface.sol
+++ b/contracts/Interface/SchedulerInterface.sol
@@ -37,10 +37,7 @@ contract SchedulerInterface {
         _;
     }
         
-    function schedule(address   _toAddress,
-                      bytes     _callData,
-                      uint[8]   _uintArgs)
+    function schedule(address   _toAddress, bytes _callData, uint[8] _uintArgs)
         doReset
         public payable returns (address);
-
 }

--- a/contracts/Interface/TransactionRequestInterface.sol
+++ b/contracts/Interface/TransactionRequestInterface.sol
@@ -8,15 +8,10 @@ contract TransactionRequestInterface {
     function claim() public payable returns (bool);
 
     // Proxy function
-    function proxy(address recipient, bytes callData)
-        public payable returns (bool);
+    function proxy(address recipient, bytes callData) public payable returns (bool);
 
     // Data accessors
-    function requestData() public view returns (address[6],
-                                                bool[3],
-                                                uint[15],
-                                                uint8[1]);
-
+    function requestData() public view returns (address[6], bool[3], uint[15], uint8[1]);
     function callData() public view returns (bytes);
 
     // Pull mechanisms for payments.

--- a/contracts/Library/ClaimLib.sol
+++ b/contracts/Library/ClaimLib.sol
@@ -1,17 +1,14 @@
 pragma solidity ^0.4.21;
 
-import 'contracts/zeppelin/SafeMath.sol';
+import "contracts/zeppelin/SafeMath.sol";
 
 library ClaimLib {
     using SafeMath for uint;
 
     struct ClaimData {
         address claimedBy;          // The address that has claimed the txRequest.
-
         uint claimDeposit;          // The deposit amount that was put down by the claimer.
-
         uint requiredDeposit;       // The required deposit to claim the txRequest.
-
         uint8 paymentModifier;      // An integer constrained between 0-100 that will be applied to the
                                     // request payment as a percentage.
     }
@@ -55,7 +52,7 @@ library ClaimLib {
             uint depositAmount;
             depositAmount = self.claimDeposit;
             self.claimDeposit = 0;
-            
+            /* solium-disable security/no-send */
             return self.claimedBy.send(depositAmount);
         }
         return true;

--- a/contracts/Library/ExecutionLib.sol
+++ b/contracts/Library/ExecutionLib.sol
@@ -22,10 +22,9 @@ library ExecutionLib {
         internal returns (bool)
     {
         /// Should never actually reach this require check, but here in case.
-        require( self.gasPrice == tx.gasprice );
-        return self.toAddress.call.value(self.callValue)
-                                  .gas(self.callGas)
-                                  (self.callData);
+        require(self.gasPrice == tx.gasprice);
+        /* solium-disable security/no-call-value */
+        return self.toAddress.call.value(self.callValue).gas(self.callGas)(self.callData);
     }
 
 
@@ -44,7 +43,7 @@ library ExecutionLib {
      * @dev Validation: ensure that the callGas is not above the total possible gas
      * for a call.
      */
-     function validateCallGas(uint callGas, uint EXTRA_GAS)
+    function validateCallGas(uint callGas, uint EXTRA_GAS)
         internal view returns (bool)
     {
         return callGas < CALL_GAS_CEILING(EXTRA_GAS);
@@ -53,7 +52,7 @@ library ExecutionLib {
     /*
      * @dev Validation: ensure that the toAddress is not set to the empty address.
      */
-     function validateToAddress(address toAddress)
+    function validateToAddress(address toAddress)
         internal pure returns (bool)
     {
         return toAddress != 0x0;

--- a/contracts/Library/PaymentLib.sol
+++ b/contracts/Library/PaymentLib.sol
@@ -63,8 +63,7 @@ library PaymentLib {
      * @dev Computes the amount to send to the address that fulfilled the request
      *       with an additional modifier. This is used when the call was claimed.
      */
-    function getBountyWithModifier(PaymentData storage self,
-                                   uint8 _paymentModifier)
+    function getBountyWithModifier(PaymentData storage self, uint8 _paymentModifier)
         internal view returns (uint)
     {
         return getBounty(self).mul(_paymentModifier).div(100);
@@ -85,6 +84,7 @@ library PaymentLib {
         if (feeAmount > 0) {
             // re-entrance protection.
             self.feeOwed = 0;
+            /* solium-disable security/no-send */
             return self.feeRecipient.send(feeAmount);
         }
         return true;
@@ -126,10 +126,10 @@ library PaymentLib {
         public pure returns (uint)
     {
         return _bounty
-                .add(_fee.mul(2))
-                .add(_callGas.mul(_gasPrice))
-                .add(_gasOverhead.mul(_gasPrice))
-                .add(_callValue);
+            .add(_fee.mul(2))
+            .add(_callGas.mul(_gasPrice))
+            .add(_gasOverhead.mul(_gasPrice))
+            .add(_callValue);
     }
 
     /*
@@ -139,13 +139,7 @@ library PaymentLib {
      * - gasReimbursment
      * - callValue
      */
-    function validateEndowment(uint _endowment,
-                               uint _bounty,
-                               uint _fee,
-                               uint _callGas,
-                               uint _callValue,
-                               uint _gasPrice,
-                               uint _gasOverhead)
+    function validateEndowment(uint _endowment, uint _bounty, uint _fee, uint _callGas, uint _callValue, uint _gasPrice, uint _gasOverhead)
         public pure returns (bool)
     {
         return _endowment >= computeEndowment(

--- a/contracts/Library/RequestLib.sol
+++ b/contracts/Library/RequestLib.sol
@@ -24,19 +24,19 @@ library RequestLib {
      *  put them in arrays. - Piper
      */
     struct SerializedRequest {
-        address[6]  addressValues;
-        bool[3]     boolValues;
-        uint[15]    uintValues;
-        uint8[1]    uint8Values;
+        address[6] addressValues;
+        bool[3] boolValues;
+        uint[15] uintValues;
+        uint8[1] uint8Values;
     }
 
     struct Request {
-        ExecutionLib.ExecutionData          txnData;
-        RequestMetaLib.RequestMeta          meta;
-        PaymentLib.PaymentData              paymentData;
-        ClaimLib.ClaimData                  claimData;
-        RequestScheduleLib.ExecutionWindow  schedule;
-        SerializedRequest                   serializedValues;
+        ExecutionLib.ExecutionData txnData;
+        RequestMetaLib.RequestMeta meta;
+        PaymentLib.PaymentData paymentData;
+        ClaimLib.ClaimData claimData;
+        RequestScheduleLib.ExecutionWindow schedule;
+        SerializedRequest serializedValues;
     }
 
     enum AbortReason {
@@ -71,35 +71,35 @@ library RequestLib {
         request.txnData.callData = _callData;
 
         // Address values
-        request.claimData.claimedBy =               0x0;
-        request.meta.createdBy =                    _addressArgs[0];
-        request.meta.owner =                        _addressArgs[1];
-        request.paymentData.feeRecipient =          _addressArgs[2];
-        request.paymentData.bountyBenefactor =      0x0;
-        request.txnData.toAddress =                 _addressArgs[3];
+        request.claimData.claimedBy = 0x0;
+        request.meta.createdBy = _addressArgs[0];
+        request.meta.owner = _addressArgs[1];
+        request.paymentData.feeRecipient = _addressArgs[2];
+        request.paymentData.bountyBenefactor = 0x0;
+        request.txnData.toAddress = _addressArgs[3];
 
         // Boolean values
-        request.meta.isCancelled =      false;
-        request.meta.wasCalled =        false;
-        request.meta.wasSuccessful =    false;
+        request.meta.isCancelled = false;
+        request.meta.wasCalled = false;
+        request.meta.wasSuccessful = false;
 
         // UInt values
-        request.claimData.claimDeposit =        0;
-        request.paymentData.fee =               _uintArgs[0];
-        request.paymentData.bounty =            _uintArgs[1];
-        request.paymentData.feeOwed =           0;
-        request.paymentData.bountyOwed =        0;
-        request.schedule.claimWindowSize =      _uintArgs[2];
-        request.schedule.freezePeriod =         _uintArgs[3];
-        request.schedule.reservedWindowSize =   _uintArgs[4];
+        request.claimData.claimDeposit = 0;
+        request.paymentData.fee = _uintArgs[0];
+        request.paymentData.bounty = _uintArgs[1];
+        request.paymentData.feeOwed = 0;
+        request.paymentData.bountyOwed = 0;
+        request.schedule.claimWindowSize = _uintArgs[2];
+        request.schedule.freezePeriod = _uintArgs[3];
+        request.schedule.reservedWindowSize = _uintArgs[4];
         // This must be capped at 1 or it throws an exception.
-        request.schedule.temporalUnit =         RequestScheduleLib.TemporalUnit(MathLib.min(_uintArgs[5], 2));
-        request.schedule.windowSize =           _uintArgs[6];
-        request.schedule.windowStart =          _uintArgs[7];
-        request.txnData.callGas =               _uintArgs[8];
-        request.txnData.callValue =             _uintArgs[9];
-        request.txnData.gasPrice =              _uintArgs[10];
-        request.claimData.requiredDeposit =     _uintArgs[11];
+        request.schedule.temporalUnit = RequestScheduleLib.TemporalUnit(MathLib.min(_uintArgs[5], 2));
+        request.schedule.windowSize = _uintArgs[6];
+        request.schedule.windowStart = _uintArgs[7];
+        request.txnData.callGas = _uintArgs[8];
+        request.txnData.callValue = _uintArgs[9];
+        request.txnData.gasPrice = _uintArgs[10];
+        request.claimData.requiredDeposit = _uintArgs[11];
 
         // Uint8 values
         request.claimData.paymentModifier = 0;
@@ -178,7 +178,7 @@ library RequestLib {
             0
         ];
 
-        require( deserialize(self, addressValues, boolValues, uintValues, uint8Values, _callData) );
+        require(deserialize(self, addressValues, boolValues, uintValues, uint8Values, _callData));
 
         return true;
     }
@@ -253,34 +253,34 @@ library RequestLib {
         self.txnData.callData = _callData;
 
         // Address values
-        self.claimData.claimedBy =              _addressValues[0];
-        self.meta.createdBy =                   _addressValues[1];
-        self.meta.owner =                       _addressValues[2];
-        self.paymentData.feeRecipient =         _addressValues[3];
-        self.paymentData.bountyBenefactor =     _addressValues[4];
-        self.txnData.toAddress =                _addressValues[5];
+        self.claimData.claimedBy = _addressValues[0];
+        self.meta.createdBy = _addressValues[1];
+        self.meta.owner = _addressValues[2];
+        self.paymentData.feeRecipient = _addressValues[3];
+        self.paymentData.bountyBenefactor = _addressValues[4];
+        self.txnData.toAddress = _addressValues[5];
 
         // Boolean values
-        self.meta.isCancelled =     _boolValues[0];
-        self.meta.wasCalled =       _boolValues[1];
-        self.meta.wasSuccessful =   _boolValues[2];
+        self.meta.isCancelled = _boolValues[0];
+        self.meta.wasCalled = _boolValues[1];
+        self.meta.wasSuccessful = _boolValues[2];
 
         // UInt values
-        self.claimData.claimDeposit =       _uintValues[0];
-        self.paymentData.fee =              _uintValues[1];
-        self.paymentData.feeOwed =          _uintValues[2];
-        self.paymentData.bounty =           _uintValues[3];
-        self.paymentData.bountyOwed =       _uintValues[4];
-        self.schedule.claimWindowSize =     _uintValues[5];
-        self.schedule.freezePeriod =        _uintValues[6];
-        self.schedule.reservedWindowSize =  _uintValues[7];
-        self.schedule.temporalUnit =        RequestScheduleLib.TemporalUnit(_uintValues[8]);
-        self.schedule.windowSize =          _uintValues[9];
-        self.schedule.windowStart =         _uintValues[10];
-        self.txnData.callGas =              _uintValues[11];
-        self.txnData.callValue =            _uintValues[12];
-        self.txnData.gasPrice =             _uintValues[13];
-        self.claimData.requiredDeposit =    _uintValues[14];
+        self.claimData.claimDeposit = _uintValues[0];
+        self.paymentData.fee = _uintValues[1];
+        self.paymentData.feeOwed = _uintValues[2];
+        self.paymentData.bounty = _uintValues[3];
+        self.paymentData.bountyOwed = _uintValues[4];
+        self.schedule.claimWindowSize = _uintValues[5];
+        self.schedule.freezePeriod = _uintValues[6];
+        self.schedule.reservedWindowSize = _uintValues[7];
+        self.schedule.temporalUnit = RequestScheduleLib.TemporalUnit(_uintValues[8]);
+        self.schedule.windowSize = _uintValues[9];
+        self.schedule.windowStart = _uintValues[10];
+        self.txnData.callGas = _uintValues[11];
+        self.txnData.callValue = _uintValues[12];
+        self.txnData.gasPrice = _uintValues[13];
+        self.claimData.requiredDeposit = _uintValues[14];
 
         // Uint8 values
         self.claimData.paymentModifier = _uint8Values[0];
@@ -356,9 +356,7 @@ library RequestLib {
         } else if (self.schedule.isAfterWindow()) {
             emit Aborted(uint8(AbortReason.AfterCallWindow));
             return false;
-        } else if (self.claimData.isClaimed() &&
-                   msg.sender != self.claimData.claimedBy &&
-                   self.schedule.inReservedWindow()) {
+        } else if (self.claimData.isClaimed() && msg.sender != self.claimData.claimedBy && self.schedule.inReservedWindow()) {
             emit Aborted(uint8(AbortReason.ReservedForClaimer));
             return false;
         } else if (self.txnData.gasPrice != tx.gasprice) {
@@ -391,7 +389,7 @@ library RequestLib {
         // Compute the fee amount
         if (self.paymentData.hasFeeRecipient()) {
             self.paymentData.feeOwed = self.paymentData.getFee()
-                                       .add(self.paymentData.feeOwed);
+                .add(self.paymentData.feeOwed);
         }
 
         // Record this locally so that we can log it later.
@@ -408,24 +406,21 @@ library RequestLib {
             // If the transaction request was claimed, we add the deposit to the bounty whether
             // or not the same agent who claimed is executing.
             self.paymentData.bountyOwed = self.claimData.claimDeposit
-                                          .add(self.paymentData.bountyOwed);
+                .add(self.paymentData.bountyOwed);
             // To prevent re-entrance we zero out the claim deposit since it is now accounted for
             // in the bounty value.
             self.claimData.claimDeposit = 0;
             // Depending on when the transaction request was claimed, we apply the modifier to the
             // bounty payment and add it to the bounty already owed.
             self.paymentData.bountyOwed = self.paymentData.getBountyWithModifier(self.claimData.paymentModifier)
-                                          .add(self.paymentData.bountyOwed);
+                .add(self.paymentData.bountyOwed);
         } else {
             // Not claimed. Just add the full bounty.
-            self.paymentData.bountyOwed = self.paymentData.getBounty()
-                                          .add(self.paymentData.bountyOwed);
+            self.paymentData.bountyOwed = self.paymentData.getBounty().add(self.paymentData.bountyOwed);
         }
 
         // Take down the amount of gas used so far in execution to compensate the executing agent.
-        uint measuredGasConsumption = startGas
-                                      .sub(gasleft())
-                                      .add(_EXECUTE_EXTRA_GAS);
+        uint measuredGasConsumption = startGas.sub(gasleft()).add(_EXECUTE_EXTRA_GAS);
 
         // // +----------------------------------------------------------------------+
         // // | NOTE: All code after this must be accounted for by EXECUTE_EXTRA_GAS |
@@ -433,8 +428,8 @@ library RequestLib {
 
         // Add the gas reimbursment amount to the bounty.
         self.paymentData.bountyOwed = measuredGasConsumption
-                                      .mul(tx.gasprice)
-                                      .add(self.paymentData.bountyOwed);
+            .mul(tx.gasprice)
+            .add(self.paymentData.bountyOwed);
 
         // Log the bounty and fee. Otherwise it is non-trivial to figure
         // out how much was payed.
@@ -549,13 +544,13 @@ library RequestLib {
         uint measuredGasConsumption;
 
         // Checks if this transactionRequest can be cancelled.
-        require( isCancellable(self) );
+        require(isCancellable(self));
 
         // Set here to prevent re-entrance attacks.
         self.meta.isCancelled = true;
 
         // Refund the claim deposit (if there is one)
-        require( self.claimData.refundDeposit() );
+        require(self.claimData.refundDeposit());
 
         // Send a reward to the cancelling agent if they are not the owner.
         // This is to incentivize the cancelling of expired transaction requests.
@@ -567,16 +562,16 @@ library RequestLib {
             // Create the rewardOwed variable, it is one-hundredth
             // of the bounty.
             uint rewardOwed = self.paymentData.bountyOwed
-                              .add(self.paymentData.bounty.div(100));
+                .add(self.paymentData.bounty.div(100));
 
             // Calculate the amount of gas cancelling agent used in this transaction.
             measuredGasConsumption = startGas
-                                     .sub(gasleft())
-                                     .add(_CANCEL_EXTRA_GAS);
-            // Add their gas fees to the reward.
+                .sub(gasleft())
+                .add(_CANCEL_EXTRA_GAS);
+            // Add their gas fees to the reward.W
             rewardOwed = measuredGasConsumption
-                         .mul(tx.gasprice)
-                         .add(rewardOwed);
+                .mul(tx.gasprice)
+                .add(rewardOwed);
 
             // Take note of the rewardPayment to log it.
             rewardPayment = rewardOwed;
@@ -603,12 +598,12 @@ library RequestLib {
         internal view returns (bool)
     {
         // Require not claimed and not cancelled.
-        require( !self.claimData.isClaimed() );
-        require( !self.meta.isCancelled );
+        require(!self.claimData.isClaimed());
+        require(!self.meta.isCancelled);
 
         // Require that it's in the claim window and the value sent is over the required deposit.
-        require( self.schedule.inClaimWindow() );
-        require( msg.value >= self.claimData.requiredDeposit );
+        require(self.schedule.inClaimWindow());
+        require(msg.value >= self.claimData.requiredDeposit);
         return true;
     }
 
@@ -620,7 +615,7 @@ library RequestLib {
     function claim(Request storage self) 
         internal returns (bool claimed)
     {
-        require( isClaimable(self) );
+        require(isClaimable(self));
 
         self.claimData.claim(self.schedule.computePaymentModifier());
         emit Claimed();
@@ -633,7 +628,7 @@ library RequestLib {
     function refundClaimDeposit(Request storage self)
         public returns (bool)
     {
-        require( self.meta.isCancelled || self.schedule.isAfterWindow() );
+        require(self.meta.isCancelled || self.schedule.isAfterWindow());
         return self.claimData.refundDeposit();
     }
 
@@ -683,9 +678,10 @@ library RequestLib {
         // Note! This does not do any checks since it is used in the execute function.
         // The public version of the function should be used for checks and in the cancel function.
         uint ownerRefund = address(this).balance
-                           .sub(self.claimData.claimDeposit)
-                           .sub(self.paymentData.bountyOwed)
-                           .sub(self.paymentData.feeOwed);
+            .sub(self.claimData.claimDeposit)
+            .sub(self.paymentData.bountyOwed)
+            .sub(self.paymentData.feeOwed);
+        /* solium-disable security/no-send */
         return self.meta.owner.send(ownerRefund);
     }
 }

--- a/contracts/Library/RequestScheduleLib.sol
+++ b/contracts/Library/RequestScheduleLib.sol
@@ -73,8 +73,8 @@ library RequestScheduleLib {
         internal view returns (uint8)
     {        
         uint paymentModifier = (getNow(self).sub(firstClaimBlock(self)))
-                                .mul(100)
-                                .div(self.claimWindowSize); 
+            .mul(100)
+            .div(self.claimWindowSize); 
         assert(paymentModifier <= 100); 
 
         return uint8(paymentModifier);
@@ -162,11 +162,7 @@ library RequestScheduleLib {
     {
         /// Checks that the firstClaimBlock is in the past or now.
         /// Checks that now is before the start of the freezePeriod.
-        if (firstClaimBlock(self) <= getNow(self)
-            && getNow(self) < freezeStart(self)) {
-                return true;
-        }
-        return false;
+        return firstClaimBlock(self) <= getNow(self) && getNow(self) < freezeStart(self);
     }
 
     /*
@@ -197,8 +193,7 @@ library RequestScheduleLib {
      * @param _windowSize The size of the execution window.
      * @return True if the reservedWindowSize is within the windowSize.
      */
-    function validateReservedWindowSize(uint _reservedWindowSize,
-                                        uint _windowSize)
+    function validateReservedWindowSize(uint _reservedWindowSize, uint _windowSize)
         public pure returns (bool)
     {
         return _reservedWindowSize <= _windowSize;
@@ -211,9 +206,7 @@ library RequestScheduleLib {
      * @param _windowStart The time in the future which represents the start of the execution window.
      * @return True if the windowStart is at least freezePeriod amount of time in the future.
      */
-    function validateWindowStart(TemporalUnit _temporalUnit,
-                                 uint _freezePeriod,
-                                 uint _windowStart) 
+    function validateWindowStart(TemporalUnit _temporalUnit, uint _freezePeriod, uint _windowStart) 
         public view returns (bool)
     {
         return _getNow(_temporalUnit).add(_freezePeriod) <= _windowStart;
@@ -225,10 +218,9 @@ library RequestScheduleLib {
     function validateTemporalUnit(uint _temporalUnitAsUInt) 
         public pure returns (bool)
     {
-        return (_temporalUnitAsUInt != uint(TemporalUnit.Null) 
-                && (_temporalUnitAsUInt == uint(TemporalUnit.Blocks)
-                    || _temporalUnitAsUInt == uint(TemporalUnit.Timestamp))
+        return (_temporalUnitAsUInt != uint(TemporalUnit.Null) &&
+            (_temporalUnitAsUInt == uint(TemporalUnit.Blocks) ||
+            _temporalUnitAsUInt == uint(TemporalUnit.Timestamp))
         );
     }
-
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -13,15 +13,15 @@ contract Migrations {
         }
     }
 
-    function Migrations() {
+    function Migrations()  public {
         owner = msg.sender;
     }
 
-    function setCompleted(uint completed) restricted {
+    function setCompleted(uint completed) restricted  public {
         last_completed_migration = completed;
     }
 
-    function upgrade(address new_address) restricted {
+    function upgrade(address new_address) restricted  public {
         Migrations upgraded = Migrations(new_address);
         upgraded.setCompleted(last_completed_migration);
     }

--- a/contracts/RequestFactory.sol
+++ b/contracts/RequestFactory.sol
@@ -21,8 +21,10 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
 
     function RequestFactory(
         address _transactionRequestCore
-    ) public {
-        require( _transactionRequestCore != 0x0 );
+    ) 
+        public 
+    {
+        require(_transactionRequestCore != 0x0);
 
         transactionRequestCore = TransactionRequestCore(_transactionRequestCore);
     }
@@ -123,11 +125,9 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
                 emit ValidationError(uint8(Errors.EmptyToAddress));
             }
 
-            // Try to return the ether sent with the message.  If this failed
-            // then revert() to force it to be returned
-            if (!msg.sender.send(msg.value)) {
-                revert();
-            }
+            // Try to return the ether sent with the message
+            msg.sender.transfer(msg.value);
+            
             return 0x0;
         }
 
@@ -204,7 +204,7 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
             bucketSize = TIMESTAMP_BUCKET_SIZE;
             sign = 1;
         } else {
-            throw;
+            revert();
         }
         return sign * int(windowStart - (windowStart % bucketSize));
     }

--- a/contracts/Scheduler/BaseScheduler.sol
+++ b/contracts/Scheduler/BaseScheduler.sol
@@ -44,23 +44,22 @@ contract BaseScheduler is SchedulerInterface {
         doReset
         public payable returns (address newRequest)
     {
-        futureTransaction.toAddress         = _toAddress;
-        futureTransaction.callData          = _callData;
-        futureTransaction.callGas           = _uintArgs[0];
-        futureTransaction.callValue         = _uintArgs[1];
-        futureTransaction.windowSize        = _uintArgs[2];
-        futureTransaction.windowStart       = _uintArgs[3];
-        futureTransaction.gasPrice          = _uintArgs[4];
-        futureTransaction.fee               = _uintArgs[5];
-        futureTransaction.bounty            = _uintArgs[6];
-        futureTransaction.requiredDeposit   = _uintArgs[7];
-
-        futureTransaction.temporalUnit      = temporalUnit;
+        futureTransaction.toAddress = _toAddress;
+        futureTransaction.callData = _callData;
+        futureTransaction.callGas = _uintArgs[0];
+        futureTransaction.callValue = _uintArgs[1];
+        futureTransaction.windowSize = _uintArgs[2];
+        futureTransaction.windowStart = _uintArgs[3];
+        futureTransaction.gasPrice = _uintArgs[4];
+        futureTransaction.fee = _uintArgs[5];
+        futureTransaction.bounty = _uintArgs[6];
+        futureTransaction.requiredDeposit = _uintArgs[7];
+        futureTransaction.temporalUnit = temporalUnit;
 
         newRequest = futureTransaction.schedule(factoryAddress, feeRecipient);
-        require( newRequest != 0x0 );
+        require(newRequest != 0x0);
 
-        NewRequest(newRequest);
+        emit NewRequest(newRequest);
         return newRequest;
     }
 }

--- a/contracts/TransactionRequestCore.sol
+++ b/contracts/TransactionRequestCore.sol
@@ -99,8 +99,9 @@ contract TransactionRequestCore is TransactionRequestInterface {
     function proxy(address _to, bytes _data)
         public payable returns (bool success)
     {
-        require(txnRequest.meta.owner == msg.sender
-                && txnRequest.schedule.isAfterWindow());
+        require(txnRequest.meta.owner == msg.sender && txnRequest.schedule.isAfterWindow());
+        
+        /* solium-disable-next-line */
         return _to.call.value(msg.value)(_data);
     }
 

--- a/contracts/_examples/DelayedPayment.sol
+++ b/contracts/_examples/DelayedPayment.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import 'contracts/Interface/SchedulerInterface.sol';
+import "contracts/Interface/SchedulerInterface.sol";
 
 /// Example of using the Scheduler from a smart contract to delay a payment.
 contract DelayedPayment {
@@ -14,7 +14,7 @@ contract DelayedPayment {
         address _scheduler,
         uint    _numBlocks,
         address _recipient
-    ) {
+    )  public {
         scheduler = SchedulerInterface(_scheduler);
         lockedUntil = block.number + _numBlocks;
         recipient = _recipient;
@@ -35,7 +35,7 @@ contract DelayedPayment {
         );
     }
 
-    function () {
+    function ()  public {
         if (this.balance > 0) {
             payout();
         } else {

--- a/contracts/_test/TransactionRecorder.sol
+++ b/contracts/_test/TransactionRecorder.sol
@@ -9,11 +9,11 @@ contract TransactionRecorder {
     bytes public lastCallData = "";
     uint public lastCallGas;
 
-    function TransactionRecorder() {
+    function TransactionRecorder()  public {
         owner = msg.sender;
     }
 
-    function() payable {
+    function() payable  public {
         lastCallGas = gasleft();
         lastCallData = msg.data;
         lastCaller = msg.sender;

--- a/contracts/zeppelin/SafeMath.sol
+++ b/contracts/zeppelin/SafeMath.sol
@@ -6,27 +6,27 @@ pragma solidity ^0.4.21;
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
-  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-    uint256 c = a * b;
-    require(a == 0 || c / a == b);
-    return c;
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a * b;
+        require(a == 0 || c / a == b);
+        return c;
   }
 
   function div(uint256 a, uint256 b) internal pure returns (uint256) {
-    // require(b > 0); // Solidity automatically throws when dividing by 0
-    uint256 c = a / b;
-    // require(a == b * c + a % b); // There is no case in which this doesn't hold
-    return c;
+  // require(b > 0); // Solidity automatically throws when dividing by 0
+  uint256 c = a / b;
+  // require(a == b * c + a % b); // There is no case in which this doesn't hold
+  return c;
   }
 
   function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-    require(b <= a);
-    return a - b;
+  require(b <= a);
+  return a - b;
   }
 
   function add(uint256 a, uint256 b) internal pure returns (uint256) {
-    uint256 c = a + b;
-    require(c >= a);
-    return c;
+  uint256 c = a + b;
+  require(c >= a);
+  return c;
   }
 }

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-console */
 const Migrations = artifacts.require("./Migrations.sol")
 
-module.exports = function(deployer) {
-    deployer.deploy(Migrations, {gas: 4700000})
+module.exports = (deployer) => {
+  deployer.deploy(Migrations, { gas: 4700000 })
     .then(() => {
-        console.log('DEPLOYED MIGRATIONS')
+      console.log('DEPLOYED MIGRATIONS')
     })
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,38 +1,35 @@
+/* eslint-disable no-console */
 const fs = require('fs')
 
 // / Contract artifacts (located in the build/ folder)
-const BaseScheduler = artifacts.require("./BaseScheduler.sol"),
-  BlockScheduler = artifacts.require("./BlockScheduler.sol"),
-  ClaimLib = artifacts.require("./ClaimLib.sol"),
-  ExecutionLib = artifacts.require("./ExecutionLib.sol"),
-  IterTools = artifacts.require("./IterTools.sol"),
-  MathLib = artifacts.require("./MathLib.sol"),
-  PaymentLib = artifacts.require("./PaymentLib.sol"),
-  RequestFactory = artifacts.require("./RequestFactory.sol"),
-  RequestFactoryInterface = artifacts.require("./RequestFactoryInterface.sol"),
-  RequestLib = artifacts.require("./RequestLib.sol"),
-  RequestMetaLib = artifacts.require("./RequestMetaLib.sol"),
-  RequestScheduleLib = artifacts.require("./RequestScheduleLib.sol"),
-  SafeMath = artifacts.require("./SafeMath.sol"),
-  SchedulerInterface = artifacts.require("./SchedulerInterface.sol"),
-  SchedulerLib = artifacts.require("./SchedulerLib.sol"),
-  TimestampScheduler = artifacts.require("./TimestampScheduler.sol"),
-  TransactionRequestCore = artifacts.require("./TransactionRequestCore.sol"),
-  TransactionRequestInterface = artifacts.require("./TransactionRequestInterface.sol");
+const BaseScheduler = artifacts.require("./BaseScheduler.sol")
+const BlockScheduler = artifacts.require("./BlockScheduler.sol")
+const ClaimLib = artifacts.require("./ClaimLib.sol")
+const ExecutionLib = artifacts.require("./ExecutionLib.sol")
+const IterTools = artifacts.require("./IterTools.sol")
+const MathLib = artifacts.require("./MathLib.sol")
+const PaymentLib = artifacts.require("./PaymentLib.sol")
+const RequestFactory = artifacts.require("./RequestFactory.sol")
+const RequestLib = artifacts.require("./RequestLib.sol")
+const RequestMetaLib = artifacts.require("./RequestMetaLib.sol")
+const RequestScheduleLib = artifacts.require("./RequestScheduleLib.sol")
+const SafeMath = artifacts.require("./SafeMath.sol")
+const SchedulerLib = artifacts.require("./SchedulerLib.sol")
+const TimestampScheduler = artifacts.require("./TimestampScheduler.sol")
+const TransactionRequestCore = artifacts.require("./TransactionRequestCore.sol")
+const TransactionRecorder = artifacts.require("./TransactionRecorder.sol")
 
-const TransactionRecorder = artifacts.require("./TransactionRecorder.sol");
-
-module.exports = function (deployer) {
+module.exports = (deployer) => {
   console.log(`${"-".repeat(30)}
 NOW DEPLOYING THE ETHEREUM ALARM CLOCK CONTRACTS...\n`)
 
   deployer.deploy([
-      [MathLib, { gas: 250000 }],
-      [IterTools, { gas: 250000 }],
-      [ExecutionLib, { gas: 250000 }],
-      [RequestMetaLib, { gas: 250000 }],
-      [SafeMath, { gas: 250000 }]
-    ])
+    [MathLib, { gas: 250000 }],
+    [IterTools, { gas: 250000 }],
+    [ExecutionLib, { gas: 250000 }],
+    [RequestMetaLib, { gas: 250000 }],
+    [SafeMath, { gas: 250000 }]
+  ])
     .then(() => {
       deployer.link(SafeMath, ClaimLib)
 
@@ -106,7 +103,12 @@ NOW DEPLOYING THE ETHEREUM ALARM CLOCK CONTRACTS...\n`)
       deployer.link(RequestLib, BlockScheduler)
       deployer.link(MathLib, BlockScheduler)
 
-      return deployer.deploy(BlockScheduler, RequestFactory.address, 0xecc9c5fff8937578141592e7E62C2D2E364311b8, { gas: 1500000 })
+      return deployer.deploy(
+        BlockScheduler,
+        RequestFactory.address,
+        0xecc9c5fff8937578141592e7E62C2D2E364311b8,
+        { gas: 1500000 }
+      )
     })
     .then(() => {
       deployer.link(SchedulerLib, TimestampScheduler)
@@ -115,7 +117,12 @@ NOW DEPLOYING THE ETHEREUM ALARM CLOCK CONTRACTS...\n`)
       deployer.link(RequestLib, TimestampScheduler)
       deployer.link(MathLib, TimestampScheduler)
 
-      return deployer.deploy(TimestampScheduler, RequestFactory.address, 0xecc9c5fff8937578141592e7E62C2D2E364311b8, { gas: 1500000 })
+      return deployer.deploy(
+        TimestampScheduler,
+        RequestFactory.address,
+        0xecc9c5fff8937578141592e7E62C2D2E364311b8,
+        { gas: 1500000 }
+      )
     })
     .then(() => deployer.deploy(TransactionRecorder, { gas: 750000 }))
     .then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,7 +209,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-            "dev": true,
             "requires": {
                 "micromatch": "2.3.11",
                 "normalize-path": "2.1.1"
@@ -228,7 +227,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true,
             "requires": {
                 "arr-flatten": "1.1.0"
             }
@@ -236,8 +234,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
         "array-find-index": {
             "version": "1.0.2",
@@ -267,8 +264,7 @@
         "array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-            "dev": true
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "arrify": {
             "version": "1.0.1",
@@ -321,8 +317,7 @@
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-            "dev": true
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
         },
         "async-eventemitter": {
             "version": "0.2.4",
@@ -429,8 +424,7 @@
         "binary-extensions": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-            "dev": true
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
         },
         "bindings": {
             "version": "1.3.0",
@@ -524,7 +518,6 @@
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true,
             "requires": {
                 "expand-range": "1.8.2",
                 "preserve": "0.2.0",
@@ -539,8 +532,7 @@
         "browser-stdout": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-            "dev": true
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
         },
         "browserify-aes": {
             "version": "1.1.1",
@@ -779,7 +771,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-            "dev": true,
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
@@ -1087,6 +1078,11 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "colors": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+            "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
+        },
         "combined-stream": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1221,7 +1217,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "dev": true,
             "requires": {
                 "lru-cache": "4.1.1",
                 "shebang-command": "1.2.0",
@@ -2538,7 +2533,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-            "dev": true,
             "requires": {
                 "cross-spawn": "5.1.0",
                 "get-stream": "3.0.0",
@@ -2553,7 +2547,6 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true,
             "requires": {
                 "is-posix-bracket": "0.1.1"
             }
@@ -2562,7 +2555,6 @@
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
             "requires": {
                 "fill-range": "2.2.3"
             }
@@ -2644,7 +2636,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
             "requires": {
                 "is-extglob": "1.0.0"
             }
@@ -2713,14 +2704,12 @@
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
         },
         "fill-range": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true,
             "requires": {
                 "is-number": "2.1.0",
                 "isobject": "2.1.0",
@@ -2794,14 +2783,12 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "for-own": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
             "requires": {
                 "for-in": "1.0.2"
             }
@@ -2862,7 +2849,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
             "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "2.8.0",
@@ -2873,14 +2859,12 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
                     "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-                    "dev": true,
                     "optional": true
                 },
                 "ajv": {
                     "version": "4.11.8",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "co": "4.6.0",
@@ -2890,21 +2874,18 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 },
                 "aproba": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
                     "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
                     "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "1.0.0",
@@ -2915,48 +2896,41 @@
                     "version": "0.2.3",
                     "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                     "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                    "dev": true,
                     "optional": true
                 },
                 "assert-plus": {
                     "version": "0.2.0",
                     "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                     "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                    "dev": true,
                     "optional": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
                     "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                    "dev": true,
                     "optional": true
                 },
                 "aws-sign2": {
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                     "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                    "dev": true,
                     "optional": true
                 },
                 "aws4": {
                     "version": "1.6.0",
                     "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
                     "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-                    "dev": true,
                     "optional": true
                 },
                 "balanced-match": {
                     "version": "0.4.2",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                    "dev": true
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                     "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "tweetnacl": "0.14.5"
@@ -2966,7 +2940,6 @@
                     "version": "0.0.9",
                     "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                     "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                    "dev": true,
                     "requires": {
                         "inherits": "2.0.3"
                     }
@@ -2975,7 +2948,6 @@
                     "version": "2.10.1",
                     "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                     "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                    "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
                     }
@@ -2984,7 +2956,6 @@
                     "version": "1.1.7",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                     "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-                    "dev": true,
                     "requires": {
                         "balanced-match": "0.4.2",
                         "concat-map": "0.0.1"
@@ -2993,34 +2964,29 @@
                 "buffer-shims": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                    "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                    "dev": true
+                    "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
                 },
                 "caseless": {
                     "version": "0.12.0",
                     "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
                     "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-                    "dev": true,
                     "optional": true
                 },
                 "co": {
                     "version": "4.6.0",
                     "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
                     "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                 },
                 "combined-stream": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                     "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                    "dev": true,
                     "requires": {
                         "delayed-stream": "1.0.0"
                     }
@@ -3028,26 +2994,22 @@
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                    "dev": true
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "cryptiles": {
                     "version": "2.0.5",
                     "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                     "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                    "dev": true,
                     "requires": {
                         "boom": "2.10.1"
                     }
@@ -3056,7 +3018,6 @@
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                     "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0"
@@ -3066,7 +3027,6 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3075,7 +3035,6 @@
                     "version": "2.6.8",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                     "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -3085,34 +3044,29 @@
                     "version": "0.4.2",
                     "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
                     "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-                    "dev": true,
                     "optional": true
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                    "dev": true
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
                     "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
-                    "dev": true,
                     "optional": true
                 },
                 "ecc-jsbn": {
                     "version": "0.1.1",
                     "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                     "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "jsbn": "0.1.1"
@@ -3122,27 +3076,23 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                     "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-                    "dev": true,
                     "optional": true
                 },
                 "extsprintf": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                    "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                    "dev": true
+                    "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                 },
                 "forever-agent": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                     "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-                    "dev": true,
                     "optional": true
                 },
                 "form-data": {
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                     "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "asynckit": "0.4.0",
@@ -3153,14 +3103,12 @@
                 "fs.realpath": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                    "dev": true
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
                 },
                 "fstream": {
                     "version": "1.0.11",
                     "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
                     "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
                         "inherits": "2.0.3",
@@ -3172,7 +3120,6 @@
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
                     "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fstream": "1.0.11",
@@ -3184,7 +3131,6 @@
                     "version": "2.7.4",
                     "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "1.1.1",
@@ -3201,7 +3147,6 @@
                     "version": "0.1.7",
                     "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                     "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0"
@@ -3211,7 +3156,6 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3220,7 +3164,6 @@
                     "version": "7.1.2",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -3233,21 +3176,18 @@
                 "graceful-fs": {
                     "version": "4.1.11",
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                    "dev": true
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
                 },
                 "har-schema": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
                     "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-                    "dev": true,
                     "optional": true
                 },
                 "har-validator": {
                     "version": "4.2.1",
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
                     "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ajv": "4.11.8",
@@ -3258,14 +3198,12 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-                    "dev": true,
                     "optional": true
                 },
                 "hawk": {
                     "version": "3.1.3",
                     "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                     "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                    "dev": true,
                     "requires": {
                         "boom": "2.10.1",
                         "cryptiles": "2.0.5",
@@ -3276,14 +3214,12 @@
                 "hoek": {
                     "version": "2.16.3",
                     "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                    "dev": true
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                 },
                 "http-signature": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                     "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "assert-plus": "0.2.0",
@@ -3295,7 +3231,6 @@
                     "version": "1.0.6",
                     "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                    "dev": true,
                     "requires": {
                         "once": "1.4.0",
                         "wrappy": "1.0.2"
@@ -3304,21 +3239,18 @@
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "ini": {
                     "version": "1.3.4",
                     "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                     "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
                     }
@@ -3327,27 +3259,23 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                     "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-                    "dev": true,
                     "optional": true
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "isstream": {
                     "version": "0.1.2",
                     "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                     "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-                    "dev": true,
                     "optional": true
                 },
                 "jodid25519": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                     "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "jsbn": "0.1.1"
@@ -3357,21 +3285,18 @@
                     "version": "0.1.1",
                     "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                     "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                    "dev": true,
                     "optional": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
                     "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                     "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                    "dev": true,
                     "optional": true
                 },
                 "json-stable-stringify": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                     "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "jsonify": "0.0.0"
@@ -3381,21 +3306,18 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                     "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-                    "dev": true,
                     "optional": true
                 },
                 "jsonify": {
                     "version": "0.0.0",
                     "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                     "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-                    "dev": true,
                     "optional": true
                 },
                 "jsprim": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
                     "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0",
@@ -3408,7 +3330,6 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3416,14 +3337,12 @@
                 "mime-db": {
                     "version": "1.27.0",
                     "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                    "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                    "dev": true
+                    "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
                 },
                 "mime-types": {
                     "version": "2.1.15",
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                     "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-                    "dev": true,
                     "requires": {
                         "mime-db": "1.27.0"
                     }
@@ -3432,7 +3351,6 @@
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
                     "requires": {
                         "brace-expansion": "1.1.7"
                     }
@@ -3440,14 +3358,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 },
                 "mkdirp": {
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3456,14 +3372,12 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true,
                     "optional": true
                 },
                 "node-pre-gyp": {
                     "version": "0.6.39",
                     "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
                     "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "1.0.2",
@@ -3483,7 +3397,6 @@
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1.1.0",
@@ -3494,7 +3407,6 @@
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
                     "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "1.1.4",
@@ -3506,28 +3418,24 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
                     "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                     "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-                    "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "dev": true,
                     "requires": {
                         "wrappy": "1.0.2"
                     }
@@ -3536,21 +3444,18 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
                     "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "1.0.2",
@@ -3560,41 +3465,35 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                    "dev": true
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
                 },
                 "performance-now": {
                     "version": "0.2.0",
                     "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
                     "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                    "dev": true
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                 },
                 "punycode": {
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                     "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true,
                     "optional": true
                 },
                 "qs": {
                     "version": "6.4.0",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
                     "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
                     "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "0.4.2",
@@ -3607,7 +3506,6 @@
                             "version": "1.2.0",
                             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3616,7 +3514,6 @@
                     "version": "2.2.9",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                     "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-                    "dev": true,
                     "requires": {
                         "buffer-shims": "1.0.0",
                         "core-util-is": "1.0.2",
@@ -3631,7 +3528,6 @@
                     "version": "2.81.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
                     "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aws-sign2": "0.6.0",
@@ -3662,7 +3558,6 @@
                     "version": "2.6.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
                     "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-                    "dev": true,
                     "requires": {
                         "glob": "7.1.2"
                     }
@@ -3670,35 +3565,30 @@
                 "safe-buffer": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                    "dev": true
+                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
                 },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-                    "dev": true,
                     "optional": true
                 },
                 "sntp": {
                     "version": "1.0.9",
                     "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                     "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                    "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
                     }
@@ -3707,7 +3597,6 @@
                     "version": "1.13.0",
                     "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
                     "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "asn1": "0.2.3",
@@ -3725,7 +3614,6 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3734,7 +3622,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
                     "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -3745,7 +3632,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                     "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "5.0.1"
                     }
@@ -3754,14 +3640,12 @@
                     "version": "0.0.5",
                     "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                     "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-                    "dev": true,
                     "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
                     }
@@ -3770,14 +3654,12 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                     "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-                    "dev": true,
                     "requires": {
                         "block-stream": "0.0.9",
                         "fstream": "1.0.11",
@@ -3788,7 +3670,6 @@
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
                     "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "2.6.8",
@@ -3805,7 +3686,6 @@
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                     "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "punycode": "1.4.1"
@@ -3815,7 +3695,6 @@
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "5.0.1"
@@ -3825,34 +3704,29 @@
                     "version": "0.14.5",
                     "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                     "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                    "dev": true,
                     "optional": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
                     "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
                     "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-                    "dev": true,
                     "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                    "dev": true
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 },
                 "uuid": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
                     "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-                    "dev": true,
                     "optional": true
                 },
                 "verror": {
                     "version": "1.3.6",
                     "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                     "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "extsprintf": "1.0.2"
@@ -3862,7 +3736,6 @@
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
                     "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "1.0.2"
@@ -3871,8 +3744,7 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 }
             }
         },
@@ -3939,7 +3811,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
             "requires": {
                 "glob-parent": "2.0.0",
                 "is-glob": "2.0.1"
@@ -3949,7 +3820,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-            "dev": true,
             "requires": {
                 "is-glob": "2.0.1"
             }
@@ -4147,8 +4017,7 @@
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "hmac-drbg": {
             "version": "1.0.1",
@@ -4346,7 +4215,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "1.11.0"
             }
@@ -4354,8 +4222,7 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
             "version": "1.0.0",
@@ -4368,14 +4235,12 @@
         "is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
         },
         "is-equal-shallow": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
             "requires": {
                 "is-primitive": "2.0.0"
             }
@@ -4383,14 +4248,12 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-            "dev": true
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
@@ -4409,7 +4272,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-            "dev": true,
             "requires": {
                 "is-extglob": "1.0.0"
             }
@@ -4428,7 +4290,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true,
             "requires": {
                 "kind-of": "3.2.2"
             }
@@ -4470,14 +4331,12 @@
         "is-posix-bracket": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
         },
         "is-primitive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
         "is-promise": {
             "version": "2.1.0",
@@ -4519,14 +4378,12 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
             "requires": {
                 "isarray": "1.0.0"
             },
@@ -4534,8 +4391,7 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
             }
         },
@@ -4661,6 +4517,11 @@
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
             "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
         },
+        "js-string-escape": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+            "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+        },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4785,7 +4646,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true,
             "requires": {
                 "is-buffer": "1.1.6"
             }
@@ -5088,7 +4948,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-            "dev": true,
             "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
@@ -5141,7 +5000,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-            "dev": true,
             "requires": {
                 "mimic-fn": "1.2.0"
             }
@@ -5246,7 +5104,6 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
             "requires": {
                 "arr-diff": "2.0.0",
                 "array-unique": "0.2.1",
@@ -5619,7 +5476,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true,
             "requires": {
                 "remove-trailing-separator": "1.1.0"
             }
@@ -5628,7 +5484,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "dev": true,
             "requires": {
                 "path-key": "2.0.1"
             }
@@ -5673,7 +5528,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
             "requires": {
                 "for-own": "0.1.5",
                 "is-extendable": "0.1.1"
@@ -5841,7 +5695,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
             "requires": {
                 "glob-base": "0.3.0",
                 "is-dotfile": "1.0.3",
@@ -5897,8 +5750,7 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.5",
@@ -5940,8 +5792,7 @@
         "pegjs": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-            "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
-            "dev": true
+            "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
         },
         "pend": {
             "version": "1.2.0",
@@ -6021,8 +5872,7 @@
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
         "process": {
             "version": "0.5.2",
@@ -6057,8 +5907,7 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "public-encrypt": {
             "version": "4.0.0",
@@ -6113,7 +5962,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-            "dev": true,
             "requires": {
                 "is-number": "3.0.0",
                 "kind-of": "4.0.0"
@@ -6123,7 +5971,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
                     "requires": {
                         "kind-of": "3.2.2"
                     },
@@ -6132,7 +5979,6 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
                             "requires": {
                                 "is-buffer": "1.1.6"
                             }
@@ -6143,7 +5989,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "1.1.6"
                     }
@@ -6240,7 +6085,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "4.1.11",
                 "minimatch": "3.0.4",
@@ -6275,7 +6119,6 @@
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
             "requires": {
                 "is-equal-shallow": "0.1.3"
             }
@@ -6283,20 +6126,17 @@
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "req-cwd": {
             "version": "1.0.1",
@@ -6613,8 +6453,7 @@
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "dev": true
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "setimmediate": {
             "version": "1.0.5",
@@ -6647,7 +6486,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "1.0.0"
             }
@@ -6655,8 +6493,7 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shelljs": {
             "version": "0.7.8",
@@ -6773,6 +6610,11 @@
             "requires": {
                 "hoek": "4.2.0"
             }
+        },
+        "sol-digger": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/sol-digger/-/sol-digger-0.0.2.tgz",
+            "integrity": "sha1-QGxKnTHiaef4jrHC6hATGOXgkCU="
         },
         "sol-explore": {
             "version": "1.6.2",
@@ -7159,6 +7001,93 @@
                 }
             }
         },
+        "solium": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.6.tgz",
+            "integrity": "sha512-hCZr5cEK2H6LVC1Lr7IGPGJ8Bs4Ktif9cmwnk3BHpoZLIwTtrNE0LUtTRBxkO3/G0GGB4OdxnnJT1pbgsJ/2Uw==",
+            "requires": {
+                "ajv": "5.5.2",
+                "chokidar": "1.7.0",
+                "colors": "1.2.1",
+                "commander": "2.14.1",
+                "js-string-escape": "1.0.1",
+                "lodash": "4.17.5",
+                "sol-digger": "0.0.2",
+                "sol-explore": "1.6.1",
+                "solium-plugin-security": "0.1.1",
+                "solparse": "2.2.4",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+                },
+                "growl": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+                },
+                "mocha": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+                    "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.11.0",
+                        "debug": "3.1.0",
+                        "diff": "3.3.1",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.3",
+                        "he": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "4.4.0"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "2.11.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+                        }
+                    }
+                },
+                "sol-explore": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
+                    "integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
+                },
+                "solparse": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.4.tgz",
+                    "integrity": "sha512-Sdyk983juUaOITdTD9U5Yc+MaX8kz4pN3wFyCRILWXW3+Ff96PxY9RLBuZINYbBgCAXN1a+kThJfFMlaXG9R6A==",
+                    "requires": {
+                        "mocha": "4.1.0",
+                        "pegjs": "0.10.0",
+                        "yargs": "10.1.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                }
+            }
+        },
+        "solium-plugin-security": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+            "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
+        },
         "source-list-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -7318,8 +7247,7 @@
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-hex-prefix": {
             "version": "1.0.0",
@@ -7498,8 +7426,7 @@
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "thenify": {
             "version": "3.3.0",
@@ -8529,7 +8456,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-            "dev": true,
             "requires": {
                 "isexe": "2.0.0"
             }
@@ -8654,8 +8580,88 @@
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+            "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+            "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "8.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "cliui": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "requires": {
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "yargs-parser": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+                    "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
+                }
+            }
         },
         "yargs-parser": {
             "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
     "name": "ethereum-alarm-clock",
-    "version": "1.0.0",
+    "version": "0.9.3",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@digix/tempo": {
             "version": "0.2.0",
@@ -18,6 +19,11 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.3.tgz",
             "integrity": "sha512-FETrNnu9+uQiICpCpFIDidesWYS4ditXvGn/zjVZunlPXCdX4HbBzHECSNbaULzZOBO+AV+CC/Qf/zITaf78Lw==",
+            "requires": {
+                "bignumber.js": "3.0.1",
+                "js-sha3": "0.5.5",
+                "utf8": "2.1.2"
+            },
             "dependencies": {
                 "bignumber.js": {
                     "version": "3.0.1",
@@ -30,6 +36,21 @@
             "version": "2.1.20",
             "resolved": "https://registry.npmjs.org/@parity/api/-/api-2.1.20.tgz",
             "integrity": "sha512-kl50p0644oDp13zlsu5VmuhstUa4CrgcZQOV+ybQ8cnXT3eVD743S0a5zC9n8Y4RJbLxHUsM7oDkbTG3cj+/OA==",
+            "requires": {
+                "@parity/abi": "2.1.3",
+                "@parity/jsonrpc": "2.1.5",
+                "@parity/wordlist": "1.1.0",
+                "bignumber.js": "3.0.1",
+                "blockies": "0.0.2",
+                "es6-error": "4.0.2",
+                "es6-promise": "4.2.4",
+                "eventemitter3": "2.0.3",
+                "isomorphic-fetch": "2.2.1",
+                "js-sha3": "0.5.5",
+                "lodash": "4.17.5",
+                "store": "2.0.12",
+                "websocket": "1.0.25"
+            },
             "dependencies": {
                 "bignumber.js": {
                     "version": "3.0.1",
@@ -51,7 +72,10 @@
         "@types/chalk": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-            "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw=="
+            "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+            "requires": {
+                "chalk": "2.3.1"
+            }
         },
         "abbrev": {
             "version": "1.0.9",
@@ -63,6 +87,9 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
             "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+            "requires": {
+                "xtend": "4.0.1"
+            },
             "dependencies": {
                 "xtend": {
                     "version": "4.0.1",
@@ -74,7 +101,11 @@
         "accepts": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-            "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8="
+            "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+            "requires": {
+                "mime-types": "2.1.17",
+                "negotiator": "0.6.1"
+            }
         },
         "acorn": {
             "version": "5.4.1",
@@ -87,6 +118,9 @@
             "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "dev": true,
+            "requires": {
+                "acorn": "4.0.13"
+            },
             "dependencies": {
                 "acorn": {
                     "version": "4.0.13",
@@ -101,6 +135,9 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
             "dependencies": {
                 "acorn": {
                     "version": "3.3.0",
@@ -113,7 +150,13 @@
         "ajv": {
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU="
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
         },
         "ajv-keywords": {
             "version": "2.1.1",
@@ -125,7 +168,12 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
         },
         "amdefine": {
             "version": "1.0.1",
@@ -147,7 +195,10 @@
         "ansi-styles": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug=="
+            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+            "requires": {
+                "color-convert": "1.9.1"
+            }
         },
         "any-promise": {
             "version": "1.3.0",
@@ -158,19 +209,29 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
+            }
         },
         "argparse": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
         },
         "arr-diff": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
         },
         "arr-flatten": {
             "version": "1.1.0",
@@ -192,7 +253,10 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -219,13 +283,21 @@
         "asn1.js": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg=="
+            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
         },
         "assert": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
             "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            }
         },
         "assert-plus": {
             "version": "1.0.0",
@@ -241,7 +313,10 @@
         "async": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "requires": {
+                "lodash": "4.17.5"
+            }
         },
         "async-each": {
             "version": "1.0.1",
@@ -252,7 +327,10 @@
         "async-eventemitter": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-            "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw=="
+            "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+            "requires": {
+                "async": "2.6.0"
+            }
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -279,6 +357,11 @@
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
             "dependencies": {
                 "ansi-styles": {
                     "version": "2.2.1",
@@ -290,7 +373,14 @@
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
                 },
                 "supports-color": {
                     "version": "2.0.0",
@@ -314,7 +404,10 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "optional": true
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
         },
         "big.js": {
             "version": "3.2.0",
@@ -347,17 +440,26 @@
         "bip66": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI="
+            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
         },
         "bl": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
+            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
         },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "blockies": {
             "version": "0.0.2",
@@ -378,29 +480,56 @@
             "version": "1.18.2",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
             "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.15"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
         "boom": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE="
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "requires": {
+                "hoek": "4.2.0"
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
         },
         "braces": {
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
         },
         "brorand": {
             "version": "1.1.0",
@@ -416,27 +545,52 @@
         "browserify-aes": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg=="
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
         },
         "browserify-cipher": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo="
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
+            }
         },
         "browserify-des": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0="
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
         },
         "browserify-rsa": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ="
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
         },
         "browserify-sha3": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
             "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+            "requires": {
+                "js-sha3": "0.3.1"
+            },
             "dependencies": {
                 "js-sha3": {
                     "version": "0.3.1",
@@ -448,18 +602,34 @@
         "browserify-sign": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg="
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
+            }
         },
         "browserify-zlib": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pako": "1.0.6"
+            }
         },
         "buffer": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
-            "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA=="
+            "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+            "requires": {
+                "base64-js": "1.2.1",
+                "ieee754": "1.1.8"
+            }
         },
         "buffer-crc32": {
             "version": "0.2.13",
@@ -501,7 +671,10 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "callsites": "0.2.0"
+            }
         },
         "callsites": {
             "version": "0.2.0",
@@ -517,7 +690,12 @@
         "camelcase-keys": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-            "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c="
+            "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+            "requires": {
+                "camelcase": "4.1.0",
+                "map-obj": "2.0.0",
+                "quick-lru": "1.1.0"
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -528,29 +706,54 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
         },
         "chai": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
+            }
         },
         "chai-as-promised": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
             "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "check-error": "1.0.2"
+            }
         },
         "chalk": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-            "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g=="
+            "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+            "requires": {
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.2.0"
+            }
         },
         "chalk-animation": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/chalk-animation/-/chalk-animation-1.4.0.tgz",
-            "integrity": "sha1-rm2H4NI8F5df2FUlC/pS69abVes="
+            "integrity": "sha1-rm2H4NI8F5df2FUlC/pS69abVes=",
+            "requires": {
+                "chalk": "2.3.1",
+                "gradient-string": "0.1.2",
+                "meow": "4.0.0"
+            }
         },
         "chardet": {
             "version": "0.4.2",
@@ -567,18 +770,36 @@
         "checkpoint-store": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
-            "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY="
+            "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+            "requires": {
+                "functional-red-black-tree": "1.0.1"
+            }
         },
         "chokidar": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+            }
         },
         "cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q=="
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
         },
         "circular-json": {
             "version": "0.3.3",
@@ -594,7 +815,10 @@
         "cli-cursor": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU="
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
         },
         "cli-spinners": {
             "version": "1.1.0",
@@ -610,7 +834,12 @@
         "cliui": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+            }
         },
         "co": {
             "version": "4.6.0",
@@ -627,6 +856,10 @@
             "resolved": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.0.1.tgz",
             "integrity": "sha1-JeorCV4enqEYcr36WEIRgTDfeLE=",
             "dev": true,
+            "requires": {
+                "request": "2.42.0",
+                "urlgrey": "0.4.0"
+            },
             "dependencies": {
                 "asn1": {
                     "version": "0.1.11",
@@ -660,13 +893,19 @@
                     "version": "0.9.5",
                     "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                     "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34"
+                    }
                 },
                 "boom": {
                     "version": "0.4.2",
                     "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                     "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
                 },
                 "caseless": {
                     "version": "0.6.0",
@@ -679,14 +918,20 @@
                     "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                     "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "delayed-stream": "0.0.5"
+                    }
                 },
                 "cryptiles": {
                     "version": "0.2.2",
                     "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                     "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "boom": "0.4.2"
+                    }
                 },
                 "delayed-stream": {
                     "version": "0.0.5",
@@ -706,14 +951,25 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                     "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "async": "0.9.2",
+                        "combined-stream": "0.0.7",
+                        "mime": "1.2.11"
+                    }
                 },
                 "hawk": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                     "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "boom": "0.4.2",
+                        "cryptiles": "0.2.2",
+                        "hoek": "0.9.1",
+                        "sntp": "0.2.4"
+                    }
                 },
                 "hoek": {
                     "version": "0.9.1",
@@ -726,7 +982,12 @@
                     "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                     "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.1.11",
+                        "assert-plus": "0.1.5",
+                        "ctype": "0.5.3"
+                    }
                 },
                 "mime": {
                     "version": "1.2.11",
@@ -764,20 +1025,46 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "request": {
                     "version": "2.42.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
                     "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.5.0",
+                        "bl": "0.9.5",
+                        "caseless": "0.6.0",
+                        "forever-agent": "0.5.2",
+                        "form-data": "0.1.4",
+                        "hawk": "1.1.1",
+                        "http-signature": "0.10.1",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "1.0.2",
+                        "node-uuid": "1.4.8",
+                        "oauth-sign": "0.4.0",
+                        "qs": "1.2.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3"
+                    }
                 },
                 "sntp": {
                     "version": "0.2.4",
                     "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                     "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
                 },
                 "tunnel-agent": {
                     "version": "0.4.3",
@@ -790,7 +1077,10 @@
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ=="
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "requires": {
+                "color-name": "1.1.3"
+            }
         },
         "color-name": {
             "version": "1.1.3",
@@ -800,7 +1090,10 @@
         "combined-stream": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
         },
         "commander": {
             "version": "2.14.1",
@@ -816,13 +1109,21 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
             "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "typedarray": "0.0.6"
+            }
         },
         "console-browserify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -864,51 +1165,104 @@
         "cors": {
             "version": "2.8.4",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY="
+            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+            "requires": {
+                "object-assign": "4.1.1",
+                "vary": "1.1.2"
+            }
         },
         "coveralls": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
             "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "js-yaml": "3.10.0",
+                "lcov-parse": "0.0.10",
+                "log-driver": "1.2.6",
+                "minimist": "1.2.0",
+                "request": "2.83.0"
+            }
         },
         "create-ecdh": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30="
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
         },
         "create-hash": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0="
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.10"
+            }
         },
         "create-hmac": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY="
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
         },
         "cross-spawn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
         },
         "cryptiles": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "requires": {
+                "boom": "5.2.0"
+            },
             "dependencies": {
                 "boom": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw=="
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
                 }
             }
         },
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg=="
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "requires": {
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.3"
+            }
         },
         "crypto-js": {
             "version": "3.1.8",
@@ -925,18 +1279,27 @@
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o="
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "requires": {
+                "array-find-index": "1.0.2"
+            }
         },
         "d": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "es5-ext": "0.10.38"
+            }
         },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
         },
         "date-now": {
             "version": "0.1.4",
@@ -953,7 +1316,10 @@
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "requires": {
+                "ms": "2.0.0"
+            }
         },
         "decamelize": {
             "version": "1.2.0",
@@ -964,6 +1330,10 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "requires": {
+                "decamelize": "1.2.0",
+                "map-obj": "1.0.1"
+            },
             "dependencies": {
                 "map-obj": {
                     "version": "1.0.1",
@@ -981,6 +1351,16 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "decompress-tarbz2": "4.1.1",
+                "decompress-targz": "4.1.1",
+                "decompress-unzip": "4.0.1",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.1.0",
+                "pify": "2.3.0",
+                "strip-dirs": "2.1.0"
+            },
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
@@ -992,17 +1372,32 @@
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M="
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "1.0.0"
+            }
         },
         "decompress-tar": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ=="
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "requires": {
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0",
+                "tar-stream": "1.5.5"
+            }
         },
         "decompress-tarbz2": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "file-type": "6.2.0",
+                "is-stream": "1.1.0",
+                "seek-bzip": "1.0.5",
+                "unbzip2-stream": "1.2.5"
+            },
             "dependencies": {
                 "file-type": {
                     "version": "6.2.0",
@@ -1014,12 +1409,23 @@
         "decompress-targz": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w=="
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0"
+            }
         },
         "decompress-unzip": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+            "requires": {
+                "file-type": "3.9.0",
+                "get-stream": "2.3.1",
+                "pify": "2.3.0",
+                "yauzl": "2.9.1"
+            },
             "dependencies": {
                 "file-type": {
                     "version": "3.9.0",
@@ -1029,7 +1435,11 @@
                 "get-stream": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
+                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -1042,7 +1452,10 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
         },
         "deep-equal": {
             "version": "0.1.2",
@@ -1059,7 +1472,10 @@
         "deferred-leveldown": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-            "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA=="
+            "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+            "requires": {
+                "abstract-leveldown": "2.6.3"
+            }
         },
         "defined": {
             "version": "0.0.0",
@@ -1072,6 +1488,15 @@
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            },
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
@@ -1094,7 +1519,11 @@
         "des.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw="
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
         },
         "destroy": {
             "version": "1.0.4",
@@ -1105,6 +1534,19 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/devp2p/-/devp2p-0.0.5.tgz",
             "integrity": "sha1-y1Vutj9Nsx85DPoI5g10JqoPlmg=",
+            "requires": {
+                "async": "1.5.2",
+                "bigi": "1.4.2",
+                "buffer-xor": "1.0.3",
+                "devp2p-dpt": "1.0.1",
+                "ecurve": "1.0.6",
+                "ethereumjs-util": "2.4.0",
+                "rlp": "2.0.0",
+                "secp256k1": "2.0.10",
+                "server-destroy": "1.0.1",
+                "sha3": "1.2.0",
+                "underscore": "1.8.3"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -1114,7 +1556,14 @@
                 "ethereumjs-util": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-2.4.0.tgz",
-                    "integrity": "sha1-8+YG8g7BY4yGx5alk/hvrAN5TmU="
+                    "integrity": "sha1-8+YG8g7BY4yGx5alk/hvrAN5TmU=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "browserify-sha3": "0.0.1",
+                        "elliptic": "6.4.0",
+                        "rlp": "2.0.0",
+                        "sha3": "1.2.0"
+                    }
                 }
             }
         },
@@ -1122,6 +1571,14 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/devp2p-dpt/-/devp2p-dpt-1.0.1.tgz",
             "integrity": "sha1-vBE5PS9ILbxXX4aolqViSZqBQ5A=",
+            "requires": {
+                "async": "1.5.2",
+                "ethereumjs-util": "2.6.0",
+                "k-bucket": "0.6.0",
+                "rlp": "2.0.0",
+                "secp256k1": "2.0.10",
+                "semaphore": "1.1.0"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -1131,7 +1588,14 @@
                 "ethereumjs-util": {
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-2.6.0.tgz",
-                    "integrity": "sha1-odeVWUYLW/mNqlAPYGsI0wYISzg="
+                    "integrity": "sha1-odeVWUYLW/mNqlAPYGsI0wYISzg=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "browserify-sha3": "0.0.1",
+                        "rlp": "2.0.0",
+                        "secp256k1": "2.0.10",
+                        "sha3": "1.2.0"
+                    }
                 }
             }
         },
@@ -1144,13 +1608,21 @@
         "diffie-hellman": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4="
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
         },
         "doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2"
+            }
         },
         "dom-walk": {
             "version": "0.1.1",
@@ -1166,7 +1638,12 @@
         "drbg.js": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-            "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs="
+            "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6"
+            }
         },
         "duplexer": {
             "version": "0.1.1",
@@ -1183,12 +1660,19 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "optional": true
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
         },
         "ecurve": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-            "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w=="
+            "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+            "requires": {
+                "bigi": "1.4.2",
+                "safe-buffer": "5.1.1"
+            }
         },
         "ee-first": {
             "version": "1.1.1",
@@ -1198,7 +1682,16 @@
         "elliptic": {
             "version": "6.4.0",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8="
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
         },
         "emojis-list": {
             "version": "2.1.0",
@@ -1214,34 +1707,56 @@
         "encoding": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "0.4.19"
+            }
         },
         "end-of-stream": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q=="
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "requires": {
+                "once": "1.4.0"
+            }
         },
         "enhanced-resolve": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "object-assign": "4.1.1",
+                "tapable": "0.2.8"
+            }
         },
         "errno": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-            "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw=="
+            "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+            "requires": {
+                "prr": "1.0.1"
+            }
         },
         "error-ex": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
         },
         "es5-ext": {
             "version": "0.10.38",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
             "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
         },
         "es6-error": {
             "version": "4.0.2",
@@ -1252,13 +1767,26 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-symbol": "3.1.1"
+            }
         },
         "es6-map": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
             "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
         },
         "es6-promise": {
             "version": "4.2.4",
@@ -1269,19 +1797,36 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
             "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
         },
         "es6-symbol": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
         },
         "es6-weak-map": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
         },
         "escape-html": {
             "version": "1.0.3",
@@ -1298,6 +1843,13 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
             "dev": true,
+            "requires": {
+                "esprima": "2.7.3",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.2.0"
+            },
             "dependencies": {
                 "esprima": {
                     "version": "2.7.3",
@@ -1316,7 +1868,10 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                     "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
                 }
             }
         },
@@ -1324,13 +1879,58 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
             "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
         },
         "eslint": {
             "version": "4.17.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
             "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
             "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.3.1",
+                "concat-stream": "1.6.0",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.3",
+                "esquery": "1.0.0",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.3.0",
+                "ignore": "3.3.7",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.10.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "4.0.2",
+                "text-table": "0.2.0"
+            },
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
@@ -1342,7 +1942,10 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
                 }
             }
         },
@@ -1350,19 +1953,29 @@
             "version": "12.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
             "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "eslint-restricted-globals": "0.1.1"
+            }
         },
         "eslint-import-resolver-node": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "resolve": "1.5.0"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
@@ -1371,12 +1984,19 @@
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
             "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
             "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "pkg-dir": "1.0.0"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
@@ -1385,18 +2005,37 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
             "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
             "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.1.1",
+                "has": "1.0.1",
+                "lodash.cond": "4.5.2",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "2.0.0"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "doctrine": {
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                    }
                 },
                 "isarray": {
                     "version": "1.0.0",
@@ -1408,19 +2047,31 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    }
                 },
                 "parse-json": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
                 },
                 "path-type": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -1432,13 +2083,22 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
                 },
                 "read-pkg-up": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
                 }
             }
         },
@@ -1452,7 +2112,11 @@
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -1464,7 +2128,11 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
             "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "acorn": "5.4.1",
+                "acorn-jsx": "3.0.1"
+            }
         },
         "esprima": {
             "version": "4.0.0",
@@ -1476,13 +2144,20 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
             "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
         },
         "esrecurse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
             "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
+            }
         },
         "estraverse": {
             "version": "4.2.0",
@@ -1504,12 +2179,27 @@
         "eth-lib": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-            "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA=="
+            "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "keccakjs": "0.2.1",
+                "nano-json-stream-parser": "0.1.2",
+                "servify": "0.1.12",
+                "ws": "3.3.3",
+                "xhr-request-promise": "0.1.2"
+            }
         },
         "ethashjs": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
             "integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+            "requires": {
+                "async": "1.5.2",
+                "buffer-xor": "1.0.3",
+                "ethereumjs-util": "4.5.0",
+                "miller-rabin": "4.0.1"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -1519,12 +2209,29 @@
                 "ethereumjs-util": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "keccakjs": "0.2.1",
+                        "rlp": "2.0.0",
+                        "secp256k1": "3.5.0"
+                    }
                 },
                 "secp256k1": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA=="
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.8.0",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -1537,43 +2244,110 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
             "integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
+            "requires": {
+                "ethereumjs-util": "4.5.0",
+                "rlp": "2.0.0"
+            },
             "dependencies": {
                 "ethereumjs-util": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "keccakjs": "0.2.1",
+                        "rlp": "2.0.0",
+                        "secp256k1": "3.5.0"
+                    }
                 },
                 "secp256k1": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA=="
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.8.0",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
         "ethereumjs-block": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
-            "integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ=="
+            "integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
+            "requires": {
+                "async": "2.6.0",
+                "ethereum-common": "0.2.0",
+                "ethereumjs-tx": "1.3.3",
+                "ethereumjs-util": "5.1.4",
+                "merkle-patricia-tree": "2.3.0"
+            }
         },
         "ethereumjs-blockchain": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-1.4.2.tgz",
-            "integrity": "sha1-5NF+ZSPhm4brgVVHsdIewqipE3M="
+            "integrity": "sha1-5NF+ZSPhm4brgVVHsdIewqipE3M=",
+            "requires": {
+                "async": "2.6.0",
+                "ethashjs": "0.0.7",
+                "ethereumjs-block": "1.7.0",
+                "ethereumjs-util": "5.1.4",
+                "flow-stoplight": "1.0.0",
+                "levelup": "1.3.9",
+                "memdown": "1.4.1",
+                "semaphore": "1.1.0"
+            }
         },
         "ethereumjs-lib": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ethereumjs-lib/-/ethereumjs-lib-3.0.0.tgz",
             "integrity": "sha1-YbLQFVLbK4nwngB7VZnW89R2zow=",
+            "requires": {
+                "devp2p": "0.0.5",
+                "devp2p-dpt": "1.0.1",
+                "ethashjs": "0.0.7",
+                "ethereumjs-account": "2.0.4",
+                "ethereumjs-block": "1.7.0",
+                "ethereumjs-blockchain": "1.4.2",
+                "ethereumjs-tx": "1.3.3",
+                "ethereumjs-util": "4.5.0",
+                "ethereumjs-vm": "1.4.1",
+                "merkle-patricia-tree": "2.3.0"
+            },
             "dependencies": {
                 "ethereumjs-util": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "keccakjs": "0.2.1",
+                        "rlp": "2.0.0",
+                        "secp256k1": "3.5.0"
+                    }
                 },
                 "secp256k1": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA=="
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.8.0",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -1581,12 +2355,19 @@
             "version": "6.0.7",
             "resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
             "integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "webpack": "3.11.0"
+            }
         },
         "ethereumjs-tx": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
             "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+            "requires": {
+                "ethereum-common": "0.0.18",
+                "ethereumjs-util": "5.1.4"
+            },
             "dependencies": {
                 "ethereum-common": {
                     "version": "0.0.18",
@@ -1599,11 +2380,30 @@
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.4.tgz",
             "integrity": "sha512-wbeTc5prEzIWFSQUcEsCAZbqubtJKy6yS+oZMY1cGG6GLYzLjm4YhC2RNrWIg8hRYnclWpnZmx2zkiufQkmd3w==",
+            "requires": {
+                "bn.js": "4.11.8",
+                "create-hash": "1.1.3",
+                "ethjs-util": "0.1.4",
+                "keccak": "1.4.0",
+                "rlp": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "secp256k1": "3.5.0"
+            },
             "dependencies": {
                 "secp256k1": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA=="
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.8.0",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -1611,6 +2411,17 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-1.4.1.tgz",
             "integrity": "sha1-qMOjORfGLXYd4ZUAI5HWym0DjAk=",
+            "requires": {
+                "async": "1.5.2",
+                "async-eventemitter": "0.2.4",
+                "ethereum-common": "0.0.16",
+                "ethereumjs-account": "2.0.4",
+                "ethereumjs-block": "1.7.0",
+                "ethereumjs-util": "4.5.0",
+                "fake-merkle-patricia-tree": "1.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "merkle-patricia-tree": "2.3.0"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -1625,12 +2436,29 @@
                 "ethereumjs-util": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y="
+                    "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "keccakjs": "0.2.1",
+                        "rlp": "2.0.0",
+                        "secp256k1": "3.5.0"
+                    }
                 },
                 "secp256k1": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA=="
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.8",
+                        "create-hash": "1.1.3",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.8.0",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -1638,6 +2466,11 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
             "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "js-sha3": "0.5.5",
+                "number-to-bn": "1.7.0"
+            },
             "dependencies": {
                 "bn.js": {
                     "version": "4.11.6",
@@ -1650,6 +2483,10 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
             "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "number-to-bn": "1.7.0"
+            },
             "dependencies": {
                 "bn.js": {
                     "version": "4.11.6",
@@ -1661,13 +2498,21 @@
         "ethjs-util": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
-            "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM="
+            "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM=",
+            "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+            }
         },
         "event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
         },
         "eventemitter3": {
             "version": "2.0.3",
@@ -1683,35 +2528,89 @@
         "evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
         },
         "execa": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
         },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
         },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
         },
         "express": {
             "version": "4.16.2",
             "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
             "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+            "requires": {
+                "accepts": "1.3.4",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.2",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "finalhandler": "1.1.0",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "2.0.2",
+                "qs": "6.5.1",
+                "range-parser": "1.2.0",
+                "safe-buffer": "5.1.1",
+                "send": "0.16.1",
+                "serve-static": "1.13.1",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.3.1",
+                "type-is": "1.6.15",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "setprototypeof": {
                     "version": "1.1.0",
@@ -1734,13 +2633,21 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
             "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.19",
+                "tmp": "0.0.33"
+            }
         },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
         },
         "extsprintf": {
             "version": "1.3.0",
@@ -1750,7 +2657,10 @@
         "fake-merkle-patricia-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
-            "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM="
+            "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+            "requires": {
+                "checkpoint-store": "1.1.0"
+            }
         },
         "fast-deep-equal": {
             "version": "1.0.0",
@@ -1771,19 +2681,29 @@
         "fd-slicer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU="
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "requires": {
+                "pend": "1.2.0"
+            }
         },
         "figures": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
         },
         "file-entry-cache": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+            }
         },
         "file-type": {
             "version": "5.2.0",
@@ -1800,17 +2720,36 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
         },
         "finalhandler": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
             "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "statuses": {
                     "version": "1.3.1",
@@ -1822,13 +2761,22 @@
         "find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "requires": {
+                "locate-path": "2.0.0"
+            }
         },
         "flat-cache": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+            }
         },
         "flow-stoplight": {
             "version": "1.0.0",
@@ -1838,7 +2786,10 @@
         "for-each": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-            "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ="
+            "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+            "requires": {
+                "is-function": "1.0.1"
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -1850,7 +2801,10 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -1860,7 +2814,12 @@
         "form-data": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8="
+            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+            }
         },
         "forwarded": {
             "version": "0.1.2",
@@ -1872,20 +2831,25 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
-        "fs-extra": {
-            "version": "0.30.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A="
-        },
         "fs-promise": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
             "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+            "requires": {
+                "any-promise": "1.3.0",
+                "fs-extra": "2.1.2",
+                "mz": "2.7.0",
+                "thenify-all": "1.6.0"
+            },
             "dependencies": {
                 "fs-extra": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
+                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0"
+                    }
                 }
             }
         },
@@ -1900,148 +2864,208 @@
             "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
             "dev": true,
             "optional": true,
+            "requires": {
+                "nan": "2.8.0",
+                "node-pre-gyp": "0.6.39"
+            },
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+                    "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
                     "dev": true,
                     "optional": true
                 },
                 "ajv": {
                     "version": "4.11.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "dev": true
                 },
                 "aproba": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+                    "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
                 },
                 "asn1": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                     "dev": true,
                     "optional": true
                 },
                 "assert-plus": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                     "dev": true,
                     "optional": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                     "dev": true,
                     "optional": true
                 },
                 "aws-sign2": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                     "dev": true,
                     "optional": true
                 },
                 "aws4": {
                     "version": "1.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                    "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                     "dev": true,
                     "optional": true
                 },
                 "balanced-match": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                     "dev": true
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
                 },
                 "block-stream": {
                     "version": "0.0.9",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
                 },
                 "boom": {
                     "version": "2.10.1",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                    "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                    "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                    "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
                     "dev": true
                 },
                 "caseless": {
                     "version": "0.12.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                     "dev": true,
                     "optional": true
                 },
                 "co": {
                     "version": "4.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                     "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "dev": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                    "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                     "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "dev": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                    "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
                 },
                 "dashdash": {
                     "version": "1.14.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -2049,93 +3073,144 @@
                 },
                 "debug": {
                     "version": "2.6.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "deep-extend": {
                     "version": "0.4.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                    "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                     "dev": true,
                     "optional": true
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                     "dev": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+                    "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
                     "dev": true,
                     "optional": true
                 },
                 "ecc-jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
                 },
                 "extend": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                     "dev": true,
                     "optional": true
                 },
                 "extsprintf": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                    "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                     "dev": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                     "dev": true,
                     "optional": true
                 },
                 "form-data": {
                     "version": "2.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true
                 },
                 "fstream": {
                     "version": "1.0.11",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
                 },
                 "fstream-ignore": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                    "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
                 },
                 "getpass": {
                     "version": "0.1.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -2143,131 +3218,196 @@
                 },
                 "glob": {
                     "version": "7.1.2",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 },
                 "har-schema": {
                     "version": "1.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                     "dev": true,
                     "optional": true
                 },
                 "har-validator": {
                     "version": "4.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "dev": true,
                     "optional": true
                 },
                 "hawk": {
                     "version": "3.1.3",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                    "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
                 },
                 "hoek": {
                     "version": "2.16.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                     "dev": true
                 },
                 "http-signature": {
                     "version": "1.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                     "dev": true
                 },
                 "ini": {
                     "version": "1.3.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                    "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                     "dev": true,
                     "optional": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true
                 },
                 "isstream": {
                     "version": "0.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                     "dev": true,
                     "optional": true
                 },
                 "jodid25519": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                    "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
                 },
                 "jsbn": {
                     "version": "0.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                     "dev": true,
                     "optional": true
                 },
                 "json-stable-stringify": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
                 },
                 "json-stringify-safe": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                     "dev": true,
                     "optional": true
                 },
                 "jsonify": {
                     "version": "0.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                    "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                     "dev": true,
                     "optional": true
                 },
                 "jsprim": {
                     "version": "1.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                    "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
@@ -2275,130 +3415,198 @@
                 },
                 "mime-db": {
                     "version": "1.27.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                    "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                     "dev": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                    "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true,
                     "optional": true
                 },
                 "node-pre-gyp": {
                     "version": "0.6.39",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+                    "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
                 },
                 "npmlog": {
                     "version": "4.1.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+                    "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "dev": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                     "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.4",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+                    "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true
                 },
                 "performance-now": {
                     "version": "0.2.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                     "dev": true
                 },
                 "punycode": {
                     "version": "1.4.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                     "dev": true,
                     "optional": true
                 },
                 "qs": {
                     "version": "6.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                    "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true
                         }
@@ -2406,150 +3614,264 @@
                 },
                 "readable-stream": {
                     "version": "2.2.9",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                    "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
                 },
                 "request": {
                     "version": "2.81.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
                 },
                 "rimraf": {
                     "version": "2.6.1",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                    "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
                 },
                 "safe-buffer": {
                     "version": "5.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                     "dev": true
                 },
                 "semver": {
                     "version": "5.3.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true,
                     "optional": true
                 },
                 "sntp": {
                     "version": "1.0.9",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                    "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
                 },
                 "sshpk": {
                     "version": "1.13.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                    "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                             "dev": true,
                             "optional": true
                         }
                     }
                 },
-                "string_decoder": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "string-width": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                    "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
                 },
                 "stringstream": {
                     "version": "0.0.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                    "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                     "dev": true,
                     "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "2.2.1",
-                    "bundled": true,
-                    "dev": true
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
                 },
                 "tar-pack": {
                     "version": "3.4.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+                    "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
                 },
                 "tough-cookie": {
                     "version": "2.3.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                    "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
                 },
                 "tweetnacl": {
                     "version": "0.14.5",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                     "dev": true,
                     "optional": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
                     "dev": true,
                     "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "dev": true
                 },
                 "uuid": {
                     "version": "3.0.1",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
                     "dev": true,
                     "optional": true
                 },
                 "verror": {
                     "version": "1.3.6",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                    "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
                 },
                 "wide-align": {
                     "version": "1.1.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "dev": true
                 }
             }
@@ -2557,7 +3879,13 @@
         "fstream": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+            }
         },
         "function-bind": {
             "version": "1.1.1",
@@ -2589,29 +3917,51 @@
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
         },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
         },
         "glob-base": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            }
         },
         "glob-parent": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-glob": "2.0.1"
+            }
         },
         "global": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8="
+            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "requires": {
+                "min-document": "2.19.0",
+                "process": "0.5.2"
+            }
         },
         "globals": {
             "version": "11.3.0",
@@ -2624,6 +3974,14 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            },
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
@@ -2636,7 +3994,23 @@
         "got": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw=="
+            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+            "requires": {
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-plain-obj": "1.1.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.0",
+                "p-cancelable": "0.3.0",
+                "p-timeout": "1.2.1",
+                "safe-buffer": "5.1.1",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "1.0.0",
+                "url-to-options": "1.0.1"
+            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -2651,7 +4025,11 @@
         "gradient-string": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-0.1.2.tgz",
-            "integrity": "sha1-F4vG4DVvFNCtrJlAwwQKuBp3g7M="
+            "integrity": "sha1-F4vG4DVvFNCtrJlAwwQKuBp3g7M=",
+            "requires": {
+                "chalk": "2.3.1",
+                "tinygradient": "0.3.1"
+            }
         },
         "growl": {
             "version": "1.9.2",
@@ -2664,6 +4042,12 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -2675,7 +4059,10 @@
                     "version": "0.4.4",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
                 }
             }
         },
@@ -2687,19 +4074,29 @@
         "har-validator": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0="
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+            }
         },
         "has": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
         },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "has-flag": {
             "version": "3.0.0",
@@ -2714,22 +4111,38 @@
         "has-to-string-tag-x": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw=="
+            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+            "requires": {
+                "has-symbol-support-x": "1.4.1"
+            }
         },
         "hash-base": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE="
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "hash.js": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA=="
+            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
         },
         "hawk": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ=="
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+            "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+            }
         },
         "he": {
             "version": "1.1.1",
@@ -2740,7 +4153,12 @@
         "hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE="
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
         },
         "hoek": {
             "version": "4.2.0",
@@ -2756,6 +4174,12 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
             "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+            "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+            },
             "dependencies": {
                 "depd": {
                     "version": "1.1.1",
@@ -2772,7 +4196,12 @@
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+            }
         },
         "https-browserify": {
             "version": "1.0.0",
@@ -2821,7 +4250,11 @@
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
         },
         "inherits": {
             "version": "2.0.3",
@@ -2838,6 +4271,22 @@
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
+            "requires": {
+                "ansi-escapes": "3.0.0",
+                "chalk": "2.3.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.5",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+            },
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
@@ -2855,13 +4304,20 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
                 }
             }
         },
@@ -2890,7 +4346,10 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "binary-extensions": "1.11.0"
+            }
         },
         "is-buffer": {
             "version": "1.1.6",
@@ -2901,7 +4360,10 @@
         "is-builtin-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
         },
         "is-dotfile": {
             "version": "1.0.3",
@@ -2913,7 +4375,10 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -2930,7 +4395,10 @@
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
         },
         "is-function": {
             "version": "1.0.1",
@@ -2941,7 +4409,10 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
         },
         "is-hex-prefixed": {
             "version": "1.0.0",
@@ -2957,7 +4428,10 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
         },
         "is-object": {
             "version": "1.0.1",
@@ -2974,13 +4448,19 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.1"
+            }
         },
         "is-path-inside": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -3047,6 +4527,9 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
@@ -3059,7 +4542,11 @@
         "isomorphic-fetch": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -3071,6 +4558,22 @@
             "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
+            "requires": {
+                "abbrev": "1.0.9",
+                "async": "1.5.2",
+                "escodegen": "1.8.1",
+                "esprima": "2.7.3",
+                "glob": "5.0.15",
+                "handlebars": "4.0.11",
+                "js-yaml": "3.10.0",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.4.0",
+                "resolve": "1.1.7",
+                "supports-color": "3.2.3",
+                "which": "1.3.0",
+                "wordwrap": "1.0.0"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -3088,7 +4591,14 @@
                     "version": "5.0.15",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "has-flag": {
                     "version": "1.0.0",
@@ -3106,20 +4616,31 @@
                     "version": "3.2.3",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
                 }
             }
         },
         "isurl": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w=="
+            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+            "requires": {
+                "has-to-string-tag-x": "1.4.1",
+                "is-object": "1.0.1"
+            }
         },
         "jade": {
             "version": "0.26.3",
             "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
             "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
             "dev": true,
+            "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+            },
             "dependencies": {
                 "commander": {
                     "version": "0.6.1",
@@ -3150,7 +4671,11 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "4.0.0"
+            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3205,7 +4730,10 @@
         "jsonfile": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
         },
         "jsonify": {
             "version": "0.0.0",
@@ -3216,33 +4744,59 @@
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
         },
         "k-bucket": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-0.6.0.tgz",
-            "integrity": "sha1-r8UyVF9p1GYpPoh7ANX8czd8Ors="
+            "integrity": "sha1-r8UyVF9p1GYpPoh7ANX8czd8Ors=",
+            "requires": {
+                "buffer-equal": "0.0.1",
+                "inherits": "2.0.3"
+            }
         },
         "keccak": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw=="
+            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+            "requires": {
+                "bindings": "1.3.0",
+                "inherits": "2.0.3",
+                "nan": "2.8.0",
+                "safe-buffer": "5.1.1"
+            }
         },
         "keccakjs": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
-            "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0="
+            "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+            "requires": {
+                "browserify-sha3": "0.0.1",
+                "sha3": "1.2.0"
+            }
         },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
         },
         "klaw": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk="
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
         },
         "lazy-cache": {
             "version": "1.0.4",
@@ -3253,7 +4807,10 @@
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
         },
         "lcov-parse": {
             "version": "0.0.10",
@@ -3269,17 +4826,40 @@
         "level-errors": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-            "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig=="
+            "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+            "requires": {
+                "errno": "0.1.6"
+            }
         },
         "level-iterator-stream": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
             "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+            "requires": {
+                "inherits": "2.0.3",
+                "level-errors": "1.1.2",
+                "readable-stream": "1.1.14",
+                "xtend": "4.0.1"
+            },
             "dependencies": {
+                "level-errors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+                    "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+                    "requires": {
+                        "errno": "0.1.6"
+                    }
+                },
                 "readable-stream": {
                     "version": "1.1.14",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "xtend": {
                     "version": "4.0.1",
@@ -3292,11 +4872,21 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
             "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+            "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "2.1.2"
+            },
             "dependencies": {
                 "readable-stream": {
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 }
             }
         },
@@ -3304,6 +4894,15 @@
             "version": "1.3.9",
             "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
             "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+            "requires": {
+                "deferred-leveldown": "1.2.2",
+                "level-codec": "7.0.1",
+                "level-errors": "1.0.5",
+                "level-iterator-stream": "1.3.1",
+                "prr": "1.0.1",
+                "semver": "5.4.1",
+                "xtend": "4.0.1"
+            },
             "dependencies": {
                 "semver": {
                     "version": "5.4.1",
@@ -3321,12 +4920,22 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
         },
         "load-json-file": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs="
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
+            }
         },
         "loader-runner": {
             "version": "2.3.0",
@@ -3338,12 +4947,21 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
+            }
         },
         "locate-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4="
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            }
         },
         "lodash": {
             "version": "4.17.5",
@@ -3354,7 +4972,11 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+            }
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -3395,7 +5017,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "3.2.0",
+                "lodash._basecreate": "3.0.3",
+                "lodash._isiterateecall": "3.0.9"
+            }
         },
         "lodash.isarguments": {
             "version": "3.1.0",
@@ -3413,18 +5040,29 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
         },
         "log-driver": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.6.tgz",
             "integrity": "sha512-iUHz4WAGsXwUmL1UergWrkFD2iTUrGLMsQDRYUWtS9FI+wSyM76vIL+THQt7vrQq5fZDGdrPSCFUfIlqII28tg==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "codecov.io": "0.0.1"
+            }
         },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg=="
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "requires": {
+                "chalk": "2.3.1"
+            }
         },
         "longest": {
             "version": "1.0.1",
@@ -3435,7 +5073,11 @@
         "loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
+            }
         },
         "lowercase-keys": {
             "version": "1.0.0",
@@ -3446,7 +5088,11 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
         },
         "ltgt": {
             "version": "2.2.0",
@@ -3456,7 +5102,10 @@
         "make-dir": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA=="
+            "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+            "requires": {
+                "pify": "3.0.0"
+            }
         },
         "map-obj": {
             "version": "2.0.0",
@@ -3467,11 +5116,19 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            },
             "dependencies": {
                 "hash-base": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg="
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -3484,17 +5141,31 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
         },
         "memdown": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
             "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+            "requires": {
+                "abstract-leveldown": "2.7.2",
+                "functional-red-black-tree": "1.0.1",
+                "immediate": "3.2.3",
+                "inherits": "2.0.3",
+                "ltgt": "2.2.0",
+                "safe-buffer": "5.1.1"
+            },
             "dependencies": {
                 "abstract-leveldown": {
                     "version": "2.7.2",
                     "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-                    "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w=="
+                    "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+                    "requires": {
+                        "xtend": "4.0.1"
+                    }
                 },
                 "xtend": {
                     "version": "4.0.1",
@@ -3512,7 +5183,11 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "errno": "0.1.6",
+                "readable-stream": "2.3.4"
+            }
         },
         "memorystream": {
             "version": "0.3.1",
@@ -3522,7 +5197,18 @@
         "meow": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-            "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw=="
+            "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+            "requires": {
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist": "1.2.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.4.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0"
+            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -3533,6 +5219,16 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.0.tgz",
             "integrity": "sha512-LKd2OoIT9Re/OG38zXbd5pyHIk2IfcOUczCwkYXl5iJIbufg9nqpweh66VfPwMkUlrEvc7YVvtQdmSrB9V9TkQ==",
+            "requires": {
+                "async": "1.5.2",
+                "ethereumjs-util": "5.1.4",
+                "level-ws": "0.0.0",
+                "levelup": "1.3.9",
+                "memdown": "1.4.1",
+                "readable-stream": "2.3.4",
+                "rlp": "2.0.0",
+                "semaphore": "1.1.0"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
@@ -3550,12 +5246,31 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
         },
         "miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
         },
         "mime": {
             "version": "1.4.1",
@@ -3570,7 +5285,10 @@
         "mime-types": {
             "version": "2.1.17",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "requires": {
+                "mime-db": "1.30.0"
+            }
         },
         "mimic-fn": {
             "version": "1.2.0",
@@ -3585,7 +5303,10 @@
         "min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU="
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "requires": {
+                "dom-walk": "0.1.1"
+            }
         },
         "minimalistic-assert": {
             "version": "1.0.0",
@@ -3600,7 +5321,10 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
         },
         "minimist": {
             "version": "1.2.0",
@@ -3610,12 +5334,19 @@
         "minimist-options": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-            "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ=="
+            "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+            "requires": {
+                "arrify": "1.0.1",
+                "is-plain-obj": "1.1.0"
+            }
         },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
             "dependencies": {
                 "minimist": {
                     "version": "0.0.8",
@@ -3627,31 +5358,62 @@
         "mkdirp-promise": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-            "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE="
+            "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
         },
         "mocha": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
             "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
             "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.9.0",
+                "debug": "2.6.8",
+                "diff": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.1",
+                "growl": "1.9.2",
+                "he": "1.1.1",
+                "json3": "3.3.2",
+                "lodash.create": "3.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "3.1.2"
+            },
             "dependencies": {
                 "commander": {
                     "version": "2.9.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
                 },
                 "debug": {
                     "version": "2.6.8",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                     "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "glob": {
                     "version": "7.1.1",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "has-flag": {
                     "version": "1.0.0",
@@ -3663,7 +5425,10 @@
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
                 }
             }
         },
@@ -3691,7 +5456,12 @@
         "mz": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "requires": {
+                "any-promise": "1.3.0",
+                "object-assign": "4.1.1",
+                "thenify-all": "1.6.0"
+            }
         },
         "nan": {
             "version": "2.8.0",
@@ -3713,11 +5483,36 @@
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.5.tgz",
             "integrity": "sha1-8pQeFWGVL6kGu7MjKM+I1MY155Q=",
+            "requires": {
+                "async": "1.5.2",
+                "ini": "1.3.5",
+                "secure-keys": "1.0.0",
+                "yargs": "3.32.0"
+            },
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
                     "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "camelcase": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+                },
+                "yargs": {
+                    "version": "3.32.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+                    "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+                    "requires": {
+                        "camelcase": "2.1.1",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "os-locale": "1.4.0",
+                        "string-width": "1.0.2",
+                        "window-size": "0.1.4",
+                        "y18n": "3.2.1"
+                    }
                 }
             }
         },
@@ -3729,19 +5524,53 @@
         "node-fetch": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+            }
         },
         "node-libs-browser": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
+            "requires": {
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
+                "path-browserify": "0.0.0",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.4",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.0",
+                "string_decoder": "1.0.3",
+                "timers-browserify": "2.0.6",
+                "tty-browserify": "0.0.0",
+                "url": "0.11.0",
+                "util": "0.10.3",
+                "vm-browserify": "0.0.4"
+            },
             "dependencies": {
                 "buffer": {
                     "version": "4.9.1",
                     "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "1.2.1",
+                        "ieee754": "1.1.8",
+                        "isarray": "1.0.0"
+                    }
                 },
                 "isarray": {
                     "version": "1.0.0",
@@ -3759,7 +5588,10 @@
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -3767,24 +5599,39 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "abbrev": "1.0.9"
+            }
         },
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw=="
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.1"
+            }
         },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
         },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "path-key": "2.0.1"
+            }
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -3795,6 +5642,10 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
             "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "strip-hex-prefix": "1.0.0"
+            },
             "dependencies": {
                 "bn.js": {
                     "version": "4.11.6",
@@ -3822,33 +5673,53 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
         },
         "oboe": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
-            "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8="
+            "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
+            "requires": {
+                "http-https": "1.0.0"
+            }
         },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "1.1.1"
+            }
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
         },
         "onetime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ="
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
         },
         "optimist": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            },
             "dependencies": {
                 "minimist": {
                     "version": "0.0.10",
@@ -3868,12 +5739,26 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
         },
         "ora": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
-            "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw=="
+            "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+            "requires": {
+                "chalk": "2.3.1",
+                "cli-cursor": "2.1.0",
+                "cli-spinners": "1.1.0",
+                "log-symbols": "2.2.0"
+            }
         },
         "os-browserify": {
             "version": "0.3.0",
@@ -3884,7 +5769,10 @@
         "os-locale": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "requires": {
+                "lcid": "1.0.0"
+            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -3905,17 +5793,26 @@
         "p-limit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng=="
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "requires": {
+                "p-try": "1.0.0"
+            }
         },
         "p-locate": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "requires": {
+                "p-limit": "1.2.0"
+            }
         },
         "p-timeout": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y="
+            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+            "requires": {
+                "p-finally": "1.0.0"
+            }
         },
         "p-try": {
             "version": "1.0.0",
@@ -3931,23 +5828,44 @@
         "parse-asn1": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI="
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "requires": {
+                "asn1.js": "4.9.2",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
+            }
         },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            }
         },
         "parse-headers": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-            "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY="
+            "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+            "requires": {
+                "for-each": "0.3.2",
+                "trim": "0.0.1"
+            }
         },
         "parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA="
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "requires": {
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.1"
+            }
         },
         "parseurl": {
             "version": "1.3.2",
@@ -3996,7 +5914,10 @@
         "path-type": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg=="
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "requires": {
+                "pify": "3.0.0"
+            }
         },
         "pathval": {
             "version": "1.1.0",
@@ -4007,7 +5928,14 @@
         "pbkdf2": {
             "version": "3.0.14",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA=="
+            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "requires": {
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
         },
         "pegjs": {
             "version": "0.10.0",
@@ -4038,25 +5966,38 @@
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "requires": {
+                "pinkie": "2.0.4"
+            }
         },
         "pkg-dir": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
             "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
             "dev": true,
+            "requires": {
+                "find-up": "1.1.2"
+            },
             "dependencies": {
                 "find-up": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "path-exists": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
                 }
             }
         },
@@ -4102,7 +6043,11 @@
         "proxy-addr": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-            "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew="
+            "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+            "requires": {
+                "forwarded": "0.1.2",
+                "ipaddr.js": "1.5.2"
+            }
         },
         "prr": {
             "version": "1.0.1",
@@ -4118,7 +6063,14 @@
         "public-encrypt": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY="
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.6"
+            }
         },
         "punycode": {
             "version": "1.4.1",
@@ -4133,7 +6085,12 @@
         "query-string": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
-            "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ=="
+            "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
+            "requires": {
+                "decode-uri-component": "0.2.0",
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -4157,18 +6114,28 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
                         }
                     }
                 },
@@ -4176,19 +6143,29 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
                 }
             }
         },
         "randombytes": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A=="
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
         },
         "randomfill": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ=="
+            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
+            }
         },
         "randomhex": {
             "version": "0.1.5",
@@ -4203,22 +6180,46 @@
         "raw-body": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k="
+            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "unpipe": "1.0.0"
+            }
         },
         "read-pkg": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k="
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "requires": {
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "3.0.0"
+            }
         },
         "read-pkg-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc="
+            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "3.0.0"
+            }
         },
         "readable-stream": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
             "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
@@ -4228,7 +6229,10 @@
                 "string_decoder": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
                 }
             }
         },
@@ -4236,7 +6240,13 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.4",
+                "set-immediate-shim": "1.0.1"
+            }
         },
         "readline-sync": {
             "version": "1.4.8",
@@ -4247,18 +6257,28 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "resolve": "1.5.0"
+            }
         },
         "redent": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo="
+            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+            "requires": {
+                "indent-string": "3.2.0",
+                "strip-indent": "2.0.0"
+            }
         },
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
@@ -4282,13 +6302,19 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
             "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "req-from": "1.0.1"
+            }
         },
         "req-from": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
             "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
             "dev": true,
+            "requires": {
+                "resolve-from": "2.0.0"
+            },
             "dependencies": {
                 "resolve-from": {
                     "version": "2.0.0",
@@ -4301,7 +6327,31 @@
         "request": {
             "version": "2.83.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw=="
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            }
         },
         "require-directory": {
             "version": "2.1.1",
@@ -4322,13 +6372,20 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
         },
         "resolve": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
         },
         "resolve-from": {
             "version": "1.0.1",
@@ -4339,29 +6396,46 @@
         "restore-cursor": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368="
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
         },
         "resumer": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
             "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "right-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
         },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w=="
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "requires": {
+                "glob": "7.1.2"
+            }
         },
         "ripemd160": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc="
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "requires": {
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
+            }
         },
         "rlp": {
             "version": "2.0.0",
@@ -4372,7 +6446,10 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-promise": "2.1.0"
+            }
         },
         "rx-lite": {
             "version": "4.0.8",
@@ -4384,7 +6461,10 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "rx-lite": "4.0.8"
+            }
         },
         "safe-buffer": {
             "version": "5.1.1",
@@ -4394,22 +6474,40 @@
         "scrypt": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-            "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0="
+            "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+            "requires": {
+                "nan": "2.8.0"
+            }
         },
         "scrypt.js": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
-            "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito="
+            "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+            "requires": {
+                "scrypt": "6.0.3",
+                "scryptsy": "1.2.1"
+            }
         },
         "scryptsy": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-            "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM="
+            "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+            "requires": {
+                "pbkdf2": "3.0.14"
+            }
         },
         "secp256k1": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-2.0.10.tgz",
-            "integrity": "sha1-x9ajwRnhykQIPDZ7BxXhhJB0F7M="
+            "integrity": "sha1-x9ajwRnhykQIPDZ7BxXhhJB0F7M=",
+            "requires": {
+                "bindings": "1.3.0",
+                "bluebird": "3.5.1",
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "nan": "2.8.0",
+                "object-assign": "4.1.1"
+            }
         },
         "secure-keys": {
             "version": "1.0.0",
@@ -4420,11 +6518,17 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+            "requires": {
+                "commander": "2.8.1"
+            },
             "dependencies": {
                 "commander": {
                     "version": "2.8.1",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ="
+                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
                 }
             }
         },
@@ -4442,11 +6546,29 @@
             "version": "0.16.1",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
             "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.1"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "statuses": {
                     "version": "1.3.1",
@@ -4458,7 +6580,13 @@
         "serve-static": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-            "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ=="
+            "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+            "requires": {
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
+                "send": "0.16.1"
+            }
         },
         "server-destroy": {
             "version": "1.0.1",
@@ -4468,7 +6596,14 @@
         "servify": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-            "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw=="
+            "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+            "requires": {
+                "body-parser": "1.18.2",
+                "cors": "2.8.4",
+                "express": "4.16.2",
+                "request": "2.83.0",
+                "xhr": "2.4.1"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -4494,18 +6629,28 @@
         "sha.js": {
             "version": "2.4.10",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-            "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA=="
+            "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
         },
         "sha3": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
-            "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo="
+            "integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
+            "requires": {
+                "nan": "2.8.0"
+            }
         },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
         },
         "shebang-regex": {
             "version": "1.0.0",
@@ -4517,25 +6662,44 @@
             "version": "0.7.8",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "interpret": "1.1.0",
+                "rechoir": "0.6.2"
+            }
         },
         "should": {
             "version": "13.2.1",
             "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
             "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "should-equal": "2.0.0",
+                "should-format": "3.0.3",
+                "should-type": "1.4.0",
+                "should-type-adaptors": "1.1.0",
+                "should-util": "1.0.0"
+            }
         },
         "should-equal": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "should-type": "1.4.0"
+            }
         },
         "should-format": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
             "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "should-type": "1.4.0",
+                "should-type-adaptors": "1.1.0"
+            }
         },
         "should-type": {
             "version": "1.4.0",
@@ -4547,7 +6711,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "should-type": "1.4.0",
+                "should-util": "1.0.0"
+            }
         },
         "should-util": {
             "version": "1.0.0",
@@ -4574,13 +6742,21 @@
         "simple-get": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-            "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg=="
+            "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
+            "requires": {
+                "decompress-response": "3.3.0",
+                "once": "1.4.0",
+                "simple-concat": "1.0.0"
+            }
         },
         "slice-ansi": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0"
+            },
             "dependencies": {
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
@@ -4593,7 +6769,10 @@
         "sntp": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg=="
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "requires": {
+                "hoek": "4.2.0"
+            }
         },
         "sol-explore": {
             "version": "1.6.2",
@@ -4605,31 +6784,72 @@
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.19.tgz",
             "integrity": "sha512-hvi/vi9rQcB73poRLoLRfQIYKwmdhrNbZlOOFCGd5v58gEsYEUr3+oHPSXhyk4CFNchWC2ojpMYrHDJNm0h4jQ==",
+            "requires": {
+                "fs-extra": "0.30.0",
+                "memorystream": "0.3.1",
+                "require-from-string": "1.2.1",
+                "semver": "5.5.0",
+                "yargs": "4.8.1"
+            },
             "dependencies": {
                 "find-up": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "fs-extra": {
+                    "version": "0.30.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1",
+                        "path-is-absolute": "1.0.1",
+                        "rimraf": "2.6.2"
+                    }
                 },
                 "load-json-file": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    }
                 },
                 "parse-json": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
                 },
                 "path-exists": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "path-type": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -4639,17 +6859,29 @@
                 "read-pkg": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
+                    }
                 },
                 "read-pkg-up": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    }
                 },
                 "strip-bom": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
                 },
                 "window-size": {
                     "version": "0.2.0",
@@ -4659,7 +6891,23 @@
                 "yargs": {
                     "version": "4.8.1",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-                    "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA="
+                    "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+                    "requires": {
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "lodash.assign": "4.2.0",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "2.4.1"
+                    }
                 }
             }
         },
@@ -4668,6 +6916,17 @@
             "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.3.5.tgz",
             "integrity": "sha512-ZAzYfC9FVix3iqBbJyYow6EPxZevkUlEp0mjJ7b1bM7HWFjoPeoUowUq7nbYECP9WVOElakX6GLewJsIQern5w==",
             "dev": true,
+            "requires": {
+                "death": "1.1.0",
+                "ethereumjs-testrpc-sc": "6.0.7",
+                "istanbul": "0.4.5",
+                "keccakjs": "0.2.1",
+                "req-cwd": "1.0.1",
+                "shelljs": "0.7.8",
+                "sol-explore": "1.6.2",
+                "solidity-parser-sc": "0.4.1",
+                "web3": "0.18.4"
+            },
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
@@ -4677,7 +6936,14 @@
                     "version": "0.18.4",
                     "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
                     "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+                        "crypto-js": "3.1.8",
+                        "utf8": "2.1.2",
+                        "xhr2": "0.1.4",
+                        "xmlhttprequest": "1.8.0"
+                    }
                 }
             }
         },
@@ -4686,6 +6952,11 @@
             "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
             "integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
             "dev": true,
+            "requires": {
+                "mocha": "2.5.3",
+                "pegjs": "0.10.0",
+                "yargs": "4.8.1"
+            },
             "dependencies": {
                 "commander": {
                     "version": "2.3.0",
@@ -4697,7 +6968,10 @@
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                     "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "0.7.1"
+                    }
                 },
                 "diff": {
                     "version": "1.4.0",
@@ -4715,19 +6989,34 @@
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "glob": {
                     "version": "3.2.11",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "minimatch": "0.3.0"
+                    }
                 },
                 "load-json-file": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    }
                 },
                 "lru-cache": {
                     "version": "2.7.3",
@@ -4739,13 +7028,29 @@
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
                 },
                 "mocha": {
                     "version": "2.5.3",
                     "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
                     "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "commander": "2.3.0",
+                        "debug": "2.2.0",
+                        "diff": "1.4.0",
+                        "escape-string-regexp": "1.0.2",
+                        "glob": "3.2.11",
+                        "growl": "1.9.2",
+                        "jade": "0.26.3",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "1.2.0",
+                        "to-iso-string": "0.0.2"
+                    }
                 },
                 "ms": {
                     "version": "0.7.1",
@@ -4757,19 +7062,30 @@
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
                 },
                 "path-exists": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "path-type": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -4781,19 +7097,31 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
+                    }
                 },
                 "read-pkg-up": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    }
                 },
                 "strip-bom": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
                 },
                 "supports-color": {
                     "version": "1.2.0",
@@ -4811,7 +7139,23 @@
                     "version": "4.8.1",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
                     "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "lodash.assign": "4.2.0",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "window-size": "0.2.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "2.4.1"
+                    }
                 }
             }
         },
@@ -4830,7 +7174,10 @@
         "spdx-correct": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "requires": {
+                "spdx-license-ids": "1.2.2"
+            }
         },
         "spdx-expression-parse": {
             "version": "1.0.4",
@@ -4846,7 +7193,10 @@
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
             "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -4857,7 +7207,17 @@
         "sshpk": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M="
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            }
         },
         "statuses": {
             "version": "1.4.0",
@@ -4873,19 +7233,33 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+            }
         },
         "stream-combiner": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
         },
         "stream-http": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
             "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
             "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            },
             "dependencies": {
                 "xtend": {
                     "version": "4.0.1",
@@ -4900,15 +7274,20 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+            }
+        },
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
         },
         "stringstream": {
             "version": "0.0.5",
@@ -4918,7 +7297,10 @@
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "strip-bom": {
             "version": "3.0.0",
@@ -4928,7 +7310,10 @@
         "strip-dirs": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g=="
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "requires": {
+                "is-natural-number": "4.0.1"
+            }
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -4939,7 +7324,10 @@
         "strip-hex-prefix": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-            "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428="
+            "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+            "requires": {
+                "is-hex-prefixed": "1.0.0"
+            }
         },
         "strip-indent": {
             "version": "2.0.0",
@@ -4955,17 +7343,39 @@
         "supports-color": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-            "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q=="
+            "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+            "requires": {
+                "has-flag": "3.0.0"
+            }
         },
         "swarm-js": {
             "version": "0.1.37",
             "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
             "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+            "requires": {
+                "bluebird": "3.5.1",
+                "buffer": "5.0.8",
+                "decompress": "4.2.0",
+                "eth-lib": "0.1.27",
+                "fs-extra": "2.1.2",
+                "fs-promise": "2.0.3",
+                "got": "7.1.0",
+                "mime-types": "2.1.17",
+                "mkdirp-promise": "5.0.1",
+                "mock-fs": "4.4.2",
+                "setimmediate": "1.0.5",
+                "tar.gz": "1.0.7",
+                "xhr-request-promise": "0.1.2"
+            },
             "dependencies": {
                 "fs-extra": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
+                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0"
+                    }
                 }
             }
         },
@@ -4974,6 +7384,14 @@
             "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.3.1",
+                "lodash": "4.17.5",
+                "slice-ansi": "1.0.0",
+                "string-width": "2.1.1"
+            },
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
@@ -4991,13 +7409,20 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
                 }
             }
         },
@@ -5011,17 +7436,38 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
             "integrity": "sha1-Df7scJIn+8yRcKvn8EaWKycUMds=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "deep-equal": "0.1.2",
+                "defined": "0.0.0",
+                "inherits": "2.0.3",
+                "jsonify": "0.0.0",
+                "resumer": "0.0.0",
+                "split": "0.2.10",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
         },
         "tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
         },
         "tar-stream": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
             "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.1",
+                "readable-stream": "2.3.4",
+                "xtend": "4.0.1"
+            },
             "dependencies": {
                 "xtend": {
                     "version": "4.0.1",
@@ -5034,6 +7480,13 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
             "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
+            "requires": {
+                "bluebird": "2.11.0",
+                "commander": "2.14.1",
+                "fstream": "1.0.11",
+                "mout": "0.11.1",
+                "tar": "2.2.1"
+            },
             "dependencies": {
                 "bluebird": {
                     "version": "2.11.0",
@@ -5051,12 +7504,18 @@
         "thenify": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-            "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk="
+            "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+            "requires": {
+                "any-promise": "1.3.0"
+            }
         },
         "thenify-all": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY="
+            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+            "requires": {
+                "thenify": "3.3.0"
+            }
         },
         "through": {
             "version": "2.3.8",
@@ -5072,7 +7531,10 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
             "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "setimmediate": "1.0.5"
+            }
         },
         "tinycolor2": {
             "version": "1.4.1",
@@ -5082,13 +7544,19 @@
         "tinygradient": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-0.3.1.tgz",
-            "integrity": "sha1-LZ5PvjSMSX7RHih6QzaDWz/RECI="
+            "integrity": "sha1-LZ5PvjSMSX7RHih6QzaDWz/RECI=",
+            "requires": {
+                "tinycolor2": "1.4.1"
+            }
         },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
         },
         "to-arraybuffer": {
             "version": "1.0.1",
@@ -5105,7 +7573,10 @@
         "tough-cookie": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE="
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "requires": {
+                "punycode": "1.4.1"
+            }
         },
         "trim": {
             "version": "0.0.1",
@@ -5121,6 +7592,9 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz",
             "integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
+            "requires": {
+                "web3": "0.20.4"
+            },
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
@@ -5128,7 +7602,19 @@
                 "web3": {
                     "version": "0.20.4",
                     "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.4.tgz",
-                    "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ="
+                    "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ=",
+                    "requires": {
+                        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+                        "crypto-js": "3.1.8",
+                        "utf8": "2.1.2",
+                        "xhr2": "0.1.4",
+                        "xmlhttprequest": "1.8.0"
+                    },
+                    "dependencies": {
+                        "bignumber.js": {
+                            "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+                        }
+                    }
                 }
             }
         },
@@ -5136,6 +7622,12 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-2.0.5.tgz",
             "integrity": "sha512-ItnN85wh4qVYPg6T4CpubI40c8dWEArtUcWcDoZ7xzj9DL7cwxqstJ0yRxyQIh4u8SRSlrOtm1dh0B7R8jtG+w==",
+            "requires": {
+                "ethjs-abi": "0.1.8",
+                "truffle-blockchain-utils": "0.0.3",
+                "truffle-contract-schema": "0.0.5",
+                "web3": "0.20.4"
+            },
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
@@ -5143,7 +7635,19 @@
                 "web3": {
                     "version": "0.20.4",
                     "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.4.tgz",
-                    "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ="
+                    "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ=",
+                    "requires": {
+                        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+                        "crypto-js": "3.1.8",
+                        "utf8": "2.1.2",
+                        "xhr2": "0.1.4",
+                        "xmlhttprequest": "1.8.0"
+                    },
+                    "dependencies": {
+                        "bignumber.js": {
+                            "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+                        }
+                    }
                 }
             }
         },
@@ -5151,6 +7655,9 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-0.0.5.tgz",
             "integrity": "sha1-Xp0gvQvyon/pQxB0gknUhO7kmWE=",
+            "requires": {
+                "crypto-js": "3.1.9-1"
+            },
             "dependencies": {
                 "crypto-js": {
                     "version": "3.1.9-1",
@@ -5168,7 +7675,10 @@
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -5180,7 +7690,10 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
         },
         "type-detect": {
             "version": "4.0.8",
@@ -5191,7 +7704,11 @@
         "type-is": {
             "version": "1.6.15",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.17"
+            }
         },
         "typedarray": {
             "version": "0.0.6",
@@ -5202,13 +7719,21 @@
         "typedarray-to-buffer": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-            "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ="
+            "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
+            "requires": {
+                "is-typedarray": "1.0.0"
+            }
         },
         "uglify-js": {
             "version": "2.8.29",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "dev": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
             "dependencies": {
                 "camelcase": {
                     "version": "1.2.1",
@@ -5220,7 +7745,12 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                    }
                 },
                 "window-size": {
                     "version": "0.1.0",
@@ -5238,7 +7768,13 @@
                     "version": "3.10.0",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                    }
                 }
             }
         },
@@ -5253,7 +7789,12 @@
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
             "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-js": "2.8.29",
+                "webpack-sources": "1.1.0"
+            }
         },
         "ultron": {
             "version": "1.1.1",
@@ -5264,6 +7805,10 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
             "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+            "requires": {
+                "buffer": "3.6.0",
+                "through": "2.3.8"
+            },
             "dependencies": {
                 "base64-js": {
                     "version": "0.0.8",
@@ -5273,7 +7818,12 @@
                 "buffer": {
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-                    "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs="
+                    "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+                    "requires": {
+                        "base64-js": "0.0.8",
+                        "ieee754": "1.1.8",
+                        "isarray": "1.0.0"
+                    }
                 },
                 "isarray": {
                     "version": "1.0.0",
@@ -5297,6 +7847,10 @@
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
             "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
             "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
             "dependencies": {
                 "punycode": {
                     "version": "1.3.2",
@@ -5309,7 +7863,10 @@
         "url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "requires": {
+                "prepend-http": "1.0.4"
+            }
         },
         "url-set-query": {
             "version": "1.0.0",
@@ -5325,7 +7882,10 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
             "integrity": "sha1-8GU1cED7NcOzEdTl3DZITZbb6gY=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "tape": "2.3.0"
+            }
         },
         "utf8": {
             "version": "2.1.2",
@@ -5337,6 +7897,9 @@
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
             "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
             "dev": true,
+            "requires": {
+                "inherits": "2.0.1"
+            },
             "dependencies": {
                 "inherits": {
                     "version": "2.0.1",
@@ -5364,7 +7927,11 @@
         "validate-npm-package-license": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+            }
         },
         "vary": {
             "version": "1.1.2",
@@ -5374,49 +7941,98 @@
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            }
         },
         "vm-browserify": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
             "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
         },
         "watchpack": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
             "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "chokidar": "1.7.0",
+                "graceful-fs": "4.1.11"
+            }
         },
         "web3": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.29.tgz",
-            "integrity": "sha1-6Xv9X94UWlAYFyTxd3+NuRg2YmA="
+            "integrity": "sha1-6Xv9X94UWlAYFyTxd3+NuRg2YmA=",
+            "requires": {
+                "web3-bzz": "1.0.0-beta.29",
+                "web3-core": "1.0.0-beta.29",
+                "web3-eth": "1.0.0-beta.29",
+                "web3-eth-personal": "1.0.0-beta.29",
+                "web3-net": "1.0.0-beta.29",
+                "web3-shh": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-bzz": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.29.tgz",
-            "integrity": "sha1-xAVVzjKB9jf8X1yD3HsIy+70K3I="
+            "integrity": "sha1-xAVVzjKB9jf8X1yD3HsIy+70K3I=",
+            "requires": {
+                "got": "7.1.0",
+                "swarm-js": "0.1.37",
+                "underscore": "1.8.3"
+            }
         },
         "web3-core": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.29.tgz",
-            "integrity": "sha1-G/uc3AHMPqcZDplh+PeIa7Qc/PE="
+            "integrity": "sha1-G/uc3AHMPqcZDplh+PeIa7Qc/PE=",
+            "requires": {
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-core-requestmanager": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-core-helpers": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.29.tgz",
-            "integrity": "sha1-kUJt7MEEEmI4TA3quRvXmnCLGQI="
+            "integrity": "sha1-kUJt7MEEEmI4TA3quRvXmnCLGQI=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-eth-iban": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-core-method": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.29.tgz",
-            "integrity": "sha1-11trk9FuK5yoxPcc3G/ubCk2HHY="
+            "integrity": "sha1-11trk9FuK5yoxPcc3G/ubCk2HHY=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-promievent": "1.0.0-beta.29",
+                "web3-core-subscriptions": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-core-promievent": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.29.tgz",
             "integrity": "sha1-zziMs052BSiFp8K9Fec1jDm32Zg=",
+            "requires": {
+                "bluebird": "3.3.1",
+                "eventemitter3": "1.1.1"
+            },
             "dependencies": {
                 "bluebird": {
                     "version": "3.3.1",
@@ -5433,12 +8049,24 @@
         "web3-core-requestmanager": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.29.tgz",
-            "integrity": "sha1-7s36oLtNJ8SEbEaFmJr2NVqxBzw="
+            "integrity": "sha1-7s36oLtNJ8SEbEaFmJr2NVqxBzw=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-providers-http": "1.0.0-beta.29",
+                "web3-providers-ipc": "1.0.0-beta.29",
+                "web3-providers-ws": "1.0.0-beta.29"
+            }
         },
         "web3-core-subscriptions": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.29.tgz",
             "integrity": "sha1-D5R1q0diCQC4gsrILsQr3NNbRKE=",
+            "requires": {
+                "eventemitter3": "1.1.1",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29"
+            },
             "dependencies": {
                 "eventemitter3": {
                     "version": "1.1.1",
@@ -5450,12 +8078,32 @@
         "web3-eth": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.29.tgz",
-            "integrity": "sha1-FTovYTcM50Qc4/JK5eFSC0K5PSQ="
+            "integrity": "sha1-FTovYTcM50Qc4/JK5eFSC0K5PSQ=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-core-subscriptions": "1.0.0-beta.29",
+                "web3-eth-abi": "1.0.0-beta.29",
+                "web3-eth-accounts": "1.0.0-beta.29",
+                "web3-eth-contract": "1.0.0-beta.29",
+                "web3-eth-iban": "1.0.0-beta.29",
+                "web3-eth-personal": "1.0.0-beta.29",
+                "web3-net": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-eth-abi": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.29.tgz",
             "integrity": "sha1-eRPArlRRAFmpjb0MubqG00IO+II=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            },
             "dependencies": {
                 "bn.js": {
                     "version": "4.11.6",
@@ -5468,6 +8116,18 @@
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.29.tgz",
             "integrity": "sha1-mG/z7X0XHam6egPByblLMb4vk+w=",
+            "requires": {
+                "bluebird": "3.3.1",
+                "crypto-browserify": "3.12.0",
+                "eth-lib": "0.2.7",
+                "scrypt.js": "0.2.0",
+                "underscore": "1.8.3",
+                "uuid": "2.0.1",
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            },
             "dependencies": {
                 "bluebird": {
                     "version": "3.3.1",
@@ -5477,7 +8137,12 @@
                 "eth-lib": {
                     "version": "0.2.7",
                     "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco="
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "elliptic": "6.4.0",
+                        "xhr-request-promise": "0.1.2"
+                    }
                 },
                 "uuid": {
                     "version": "2.0.1",
@@ -5489,57 +8154,121 @@
         "web3-eth-contract": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.29.tgz",
-            "integrity": "sha1-xXTGOpCEi5gvF2tBwt76tFmMSmk="
+            "integrity": "sha1-xXTGOpCEi5gvF2tBwt76tFmMSmk=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-core-promievent": "1.0.0-beta.29",
+                "web3-core-subscriptions": "1.0.0-beta.29",
+                "web3-eth-abi": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-eth-iban": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.29.tgz",
-            "integrity": "sha1-eXSsE2X2WXdsxqv1xV4ty8Jw44E="
+            "integrity": "sha1-eXSsE2X2WXdsxqv1xV4ty8Jw44E=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-eth-personal": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.29.tgz",
-            "integrity": "sha1-qk0e+k7hR4fzcnuxw2DxLtfIqqI="
+            "integrity": "sha1-qk0e+k7hR4fzcnuxw2DxLtfIqqI=",
+            "requires": {
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-net": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-net": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.29.tgz",
-            "integrity": "sha1-8zYaw9o26FkB7hVh61K+5S2dS+4="
+            "integrity": "sha1-8zYaw9o26FkB7hVh61K+5S2dS+4=",
+            "requires": {
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-utils": "1.0.0-beta.29"
+            }
         },
         "web3-providers-http": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.29.tgz",
-            "integrity": "sha1-UAFYhAnMKxj4qqwJINUuOQR+Ir0="
+            "integrity": "sha1-UAFYhAnMKxj4qqwJINUuOQR+Ir0=",
+            "requires": {
+                "web3-core-helpers": "1.0.0-beta.29",
+                "xhr2": "0.1.4"
+            }
         },
         "web3-providers-ipc": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.29.tgz",
-            "integrity": "sha1-uMLaC1ql3KoqZc/tq/VXKyJV2rk="
+            "integrity": "sha1-uMLaC1ql3KoqZc/tq/VXKyJV2rk=",
+            "requires": {
+                "oboe": "2.1.3",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29"
+            }
         },
         "web3-providers-ws": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.29.tgz",
             "integrity": "sha1-LtnZsoj2IZs3+gV8XlsM/t3NAbs=",
+            "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.29",
+                "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "websocket": {
-                    "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+                    "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+                    "requires": {
+                        "debug": "2.6.9",
+                        "nan": "2.8.0",
+                        "typedarray-to-buffer": "3.1.2",
+                        "yaeti": "0.0.6"
+                    }
                 }
             }
         },
         "web3-shh": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.29.tgz",
-            "integrity": "sha1-HnA1Utrpa/Z7Y+RoNRSxRV+aWEY="
+            "integrity": "sha1-HnA1Utrpa/Z7Y+RoNRSxRV+aWEY=",
+            "requires": {
+                "web3-core": "1.0.0-beta.29",
+                "web3-core-method": "1.0.0-beta.29",
+                "web3-core-subscriptions": "1.0.0-beta.29",
+                "web3-net": "1.0.0-beta.29"
+            }
         },
         "web3-utils": {
             "version": "1.0.0-beta.29",
             "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.29.tgz",
             "integrity": "sha1-iZkl7RWyDV9wgU34o1Ji5Nb8pqk=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "eth-lib": "0.1.27",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.8.3",
+                "utf8": "2.1.1"
+            },
             "dependencies": {
                 "bn.js": {
                     "version": "4.11.6",
@@ -5558,12 +8287,41 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
             "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
             "dev": true,
+            "requires": {
+                "acorn": "5.4.1",
+                "acorn-dynamic-import": "2.0.2",
+                "ajv": "6.1.1",
+                "ajv-keywords": "3.1.0",
+                "async": "2.6.0",
+                "enhanced-resolve": "3.4.1",
+                "escope": "3.6.0",
+                "interpret": "1.1.0",
+                "json-loader": "0.5.7",
+                "json5": "0.5.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "mkdirp": "0.5.1",
+                "node-libs-browser": "2.1.0",
+                "source-map": "0.5.7",
+                "supports-color": "4.5.0",
+                "tapable": "0.2.8",
+                "uglifyjs-webpack-plugin": "0.4.6",
+                "watchpack": "1.4.0",
+                "webpack-sources": "1.1.0",
+                "yargs": "8.0.2"
+            },
             "dependencies": {
                 "ajv": {
                     "version": "6.1.1",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
                     "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
                 },
                 "ajv-keywords": {
                     "version": "3.1.0",
@@ -5593,25 +8351,42 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                    }
                 },
                 "os-locale": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
                 },
                 "parse-json": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
                 },
                 "path-type": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pify": "2.3.0"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -5623,31 +8398,50 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                    }
                 },
                 "read-pkg-up": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                    }
                 },
                 "string-width": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
                 },
                 "supports-color": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
                 },
                 "which-module": {
                     "version": "2.0.0",
@@ -5659,13 +8453,31 @@
                     "version": "8.0.2",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
                 },
                 "yargs-parser": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
                 }
             }
         },
@@ -5674,6 +8486,10 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
+            "requires": {
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
+            },
             "dependencies": {
                 "source-map": {
                     "version": "0.6.1",
@@ -5687,11 +8503,20 @@
             "version": "1.0.25",
             "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.25.tgz",
             "integrity": "sha512-M58njvi6ZxVb5k7kpnHh2BvNKuBWiwIYvsToErBzWhvBZYwlEiLcyLrG41T1jRcrY9ettqPYEqduLI7ul54CVQ==",
+            "requires": {
+                "debug": "2.6.9",
+                "nan": "2.8.0",
+                "typedarray-to-buffer": "3.1.2",
+                "yaeti": "0.0.6"
+            },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
@@ -5704,7 +8529,10 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
         },
         "which-module": {
             "version": "1.0.0",
@@ -5725,7 +8553,11 @@
         "wrap-ansi": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            }
         },
         "wrappy": {
             "version": "1.0.2",
@@ -5736,17 +8568,31 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
         },
         "ws": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA=="
+            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+            }
         },
         "xhr": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
             "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+            "requires": {
+                "global": "4.3.2",
+                "is-function": "1.0.1",
+                "parse-headers": "2.0.1",
+                "xtend": "4.0.1"
+            },
             "dependencies": {
                 "xtend": {
                     "version": "4.0.1",
@@ -5758,12 +8604,24 @@
         "xhr-request": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-            "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA=="
+            "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+            "requires": {
+                "buffer-to-arraybuffer": "0.0.5",
+                "object-assign": "4.1.1",
+                "query-string": "5.1.0",
+                "simple-get": "2.7.0",
+                "timed-out": "4.0.1",
+                "url-set-query": "1.0.0",
+                "xhr": "2.4.1"
+            }
         },
         "xhr-request-promise": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-            "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0="
+            "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+            "requires": {
+                "xhr-request": "1.1.0"
+            }
         },
         "xhr2": {
             "version": "0.1.4",
@@ -5778,7 +8636,10 @@
         "xtend": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+            "requires": {
+                "object-keys": "0.4.0"
+            }
         },
         "y18n": {
             "version": "3.2.1",
@@ -5796,22 +8657,14 @@
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
         },
-        "yargs": {
-            "version": "3.32.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-                }
-            }
-        },
         "yargs-parser": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
             "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+            "requires": {
+                "camelcase": "3.0.0",
+                "lodash.assign": "4.2.0"
+            },
             "dependencies": {
                 "camelcase": {
                     "version": "3.0.0",
@@ -5823,7 +8676,11 @@
         "yauzl": {
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8="
+            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "scripts": {
         "test": "truffle test test/block-scheduling-tests/* && truffle test test/request-factory-tests/* && truffle test test/timestamp-scheduling-tests/timestampClaiming.js && truffle test test/timestamp-scheduling-tests/timestampExecution.js && truffle test test/timestamp-scheduling-tests/timestampReserved.js && truffle test test/timestamp-scheduling-tests/timestampScheduler.js && truffle test test/transaction-request/* && truffle test test/others/* && truffle test test/integration/*",
         "coverage": "./node_modules/.bin/solidity-coverage",
-        "lint": "eslint ."
+        "lint": "./node_modules/eslint/bin/eslint.js .",
+        "solium": "./node_modules/solium/bin/solium.js -d contracts --fix"
     },
     "repository": {
         "type": "git",
@@ -42,6 +43,7 @@
         "ora": "^1.3.0",
         "readline-sync": "^1.4.7",
         "solc": "^0.4.19",
+        "solium": "^1.1.6",
         "truffle-contract": "^2.0.5",
         "web3": "^1.0.0-beta.18",
         "web3-core-method": "^1.0.0-beta.27",
@@ -61,6 +63,7 @@
         "solidity-coverage": "^0.3.5"
     },
     "pre-commit": [
-        "lint"
+        "lint",
+        "solium"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     },
     "scripts": {
         "test": "truffle test test/block-scheduling-tests/* && truffle test test/request-factory-tests/* && truffle test test/timestamp-scheduling-tests/timestampClaiming.js && truffle test test/timestamp-scheduling-tests/timestampExecution.js && truffle test test/timestamp-scheduling-tests/timestampReserved.js && truffle test test/timestamp-scheduling-tests/timestampScheduler.js && truffle test test/transaction-request/* && truffle test test/others/* && truffle test test/integration/*",
-        "coverage": "./node_modules/.bin/solidity-coverage"
+        "coverage": "./node_modules/.bin/solidity-coverage",
+        "lint": "eslint ."
     },
     "repository": {
         "type": "git",
@@ -58,5 +59,8 @@
         "mocha": "^3.5.3",
         "should": "^13.1.0",
         "solidity-coverage": "^0.3.5"
-    }
+    },
+    "pre-commit": [
+        "lint"
+    ]
 }

--- a/test/block-scheduling-tests/blockClaiming.js
+++ b/test/block-scheduling-tests/blockClaiming.js
@@ -239,12 +239,12 @@ contract("Block claiming", async (accounts) => {
     const requestData = await RequestData.from(txRequest)
 
     const claimAt =
-      requestData.schedule.windowStart -
+      (requestData.schedule.windowStart -
       requestData.schedule.freezePeriod -
-      requestData.schedule.claimWindowSize +
-      Math.floor(requestData.schedule.claimWindowSize * 2 / 3)
+      requestData.schedule.claimWindowSize) +
+      Math.floor((requestData.schedule.claimWindowSize * 2) / 3)
 
-    const expectedPaymentModifier = Math.floor(100 * 2 / 3)
+    const expectedPaymentModifier = Math.floor((100 * 2) / 3)
 
     expect(requestData.claimData.paymentModifier).to.equal(0)
 

--- a/test/block-scheduling-tests/blockScheduler.js
+++ b/test/block-scheduling-tests/blockScheduler.js
@@ -42,9 +42,7 @@ contract("Block scheduling", (accounts) => {
     const transactionRequestCore = await TransactionRequestCore.deployed()
     expect(transactionRequestCore.address).to.exist
 
-    requestFactory = await RequestFactory.new(
-      transactionRequestCore.address
-    )
+    requestFactory = await RequestFactory.new(transactionRequestCore.address)
     blockScheduler = await BlockScheduler.new(
       requestFactory.address,
       "0xecc9c5fff8937578141592e7E62C2D2E364311b8"
@@ -122,7 +120,8 @@ contract("Block scheduling", (accounts) => {
     expect(parseInt(balOfTxRequest, 10)).to.equal(requestData.calcEndowment())
 
     // Sanity check
-    expect(requestData.calcEndowment()).to.equal(computeEndowment(bounty, fee, 1212121, 123454321, gasPrice))
+    const expectedEndowment = computeEndowment(bounty, fee, 1212121, 123454321, gasPrice)
+    expect(requestData.calcEndowment()).to.equal(expectedEndowment)
 
     // Sanity check
     expect(endowment.toNumber()).to.equal(requestData.calcEndowment())

--- a/test/integration/scheduleToExecute.js
+++ b/test/integration/scheduleToExecute.js
@@ -24,7 +24,6 @@ contract("Schedule to execution flow", (accounts) => {
 
   let blockScheduler
   let requestFactory
-  let requestTracker
   let txRecorder
   let txRequest
 
@@ -37,9 +36,7 @@ contract("Schedule to execution flow", (accounts) => {
     const transactionRequestCore = await TransactionRequestCore.deployed()
     expect(transactionRequestCore.address).to.exist
 
-    requestFactory = await RequestFactory.new(
-        transactionRequestCore.address
-    )
+    requestFactory = await RequestFactory.new(transactionRequestCore.address)
     expect(requestFactory.address).to.exist
 
     blockScheduler = await BlockScheduler.new(
@@ -98,7 +95,7 @@ contract("Schedule to execution flow", (accounts) => {
 
     expect(requestData.schedule.windowStart).to.equal(windowStart)
 
-    expect(requestData.txData.gasPrice).to.equal(parseInt(gasPrice))
+    expect(requestData.txData.gasPrice).to.equal(parseInt(gasPrice, 10))
 
     expect(requestData.paymentData.fee).to.equal(98765)
 

--- a/test/request-factory-tests/bucketCalculations.js
+++ b/test/request-factory-tests/bucketCalculations.js
@@ -12,7 +12,7 @@ const TransactionRequestCore = artifacts.require("./TransactionRequestCore.sol")
 
 // Note - these tests were checked very well and should never be wrong.
 // If they start failing - look in the contracts.
-contract("Request factory", async (accounts) => {
+contract("Request factory", async () => {
   describe("getBucket()", async () => {
     let transactionRequestCore
     let requestFactory
@@ -34,7 +34,7 @@ contract("Request factory", async (accounts) => {
       const intMax = new BigNumber(2).pow(255).minus(1)
       const now = new BigNumber(2).pow(256).minus(1)
       const bucket = await requestFactory.getBucket(now, 2)
-      
+
       const expected = intMax.plus(1).times(-2).plus(calculateTimestampBucket(now)) // overflows
 
       expect(bucket.equals(expected)).to.be.true

--- a/test/request-factory-tests/requestFactory.js
+++ b/test/request-factory-tests/requestFactory.js
@@ -68,9 +68,7 @@ contract("Request factory", async (accounts) => {
     expect(transactionRequestCore.address).to.exist
 
     // Pass the request tracker to the factory
-    const requestFactory = await RequestFactory.new(
-        transactionRequestCore.address
-    )
+    const requestFactory = await RequestFactory.new(transactionRequestCore.address)
     expect(requestFactory.address).to.exist
 
     const params = [

--- a/test/timestamp-scheduling-tests/timestampExecution.js
+++ b/test/timestamp-scheduling-tests/timestampExecution.js
@@ -38,8 +38,7 @@ contract("Timestamp execution", async (accounts) => {
   beforeEach(async () => {
     const curBlock = await config.web3.eth.getBlock("latest")
     const { timestamp } = curBlock
-
-    const windowStart = timestamp + 10 * DAY
+    const windowStart = timestamp + (DAY * 10)
 
     // / Deploy a fresh transactionRecorder
     txRecorder = await TransactionRecorder.new()

--- a/test/timestamp-scheduling-tests/timestampScheduler.js
+++ b/test/timestamp-scheduling-tests/timestampScheduler.js
@@ -24,7 +24,6 @@ contract("Timestamp scheduling", (accounts) => {
   const testData32 = ethUtil.bufferToHex(Buffer.from("32".padEnd(32, "AF01")))
 
   let requestFactory
-  let requestTracker
   let timestampScheduler
   let transactionRecorder
 
@@ -34,9 +33,7 @@ contract("Timestamp scheduling", (accounts) => {
     expect(transactionRequestCore.address).to.exist
 
     // Request factory
-    requestFactory = await RequestFactory.new(
-        transactionRequestCore.address
-    )
+    requestFactory = await RequestFactory.new(transactionRequestCore.address)
     expect(requestFactory.address).to.exist
 
     // Timestamp scheduler
@@ -92,7 +89,8 @@ contract("Timestamp scheduling", (accounts) => {
     // .to.equal(requestData.calcEndowment())
 
     // Sanity check
-    expect(requestData.calcEndowment()).to.equal(computeEndowment(bounty, fee, 1212121, 123454321, gasPrice))
+    const expectedEndowment = computeEndowment(bounty, fee, 1212121, 123454321, gasPrice)
+    expect(requestData.calcEndowment()).to.equal(expectedEndowment)
 
     expect(requestData.txData.toAddress).to.equal(transactionRecorder.address)
 

--- a/test/transaction-request/accounting.js
+++ b/test/transaction-request/accounting.js
@@ -11,7 +11,7 @@ const TransactionRequestCore = artifacts.require("./TransactionRequestCore.sol")
 // Brings in config.web3 (v1.0.0)
 const config = require("../../config")
 const { RequestData } = require("../dataHelpers.js")
-const { wait, waitUntilBlock } = require("@digix/tempo")(web3)
+const { waitUntilBlock } = require("@digix/tempo")(web3)
 
 const { toBN } = config.web3.utils
 
@@ -224,7 +224,6 @@ contract("Test accounting", async (accounts) => {
     const afterBountyBal = await config.web3.eth.getBalance(accounts[1])
 
     const Executed = executeTx.logs.find(e => e.event === "Executed")
-    const feeAmt = Executed.args.fee.toNumber()
     const bountyAmt = Executed.args.bounty.toNumber()
 
     const executeGasUsed = executeTx.receipt.gasUsed
@@ -233,9 +232,7 @@ contract("Test accounting", async (accounts) => {
     const expectedBounty =
       parseInt(claimDeposit, 10) +
       executeGasCost +
-      Math.floor(requestData.claimData.paymentModifier *
-          requestData.paymentData.bounty /
-          100)
+      Math.floor((requestData.claimData.paymentModifier * requestData.paymentData.bounty) / 100)
 
     expect(bountyAmt).to.be.at.least(expectedBounty)
 
@@ -246,7 +243,7 @@ contract("Test accounting", async (accounts) => {
       .toNumber()
     const expectedDiff =
       bountyAmt - claimDeposit - executeGasCost - claimGasCost
-    if (diff == expectedDiff) expect(diff).to.equal(expectedDiff)
+    if (diff === expectedDiff) expect(diff).to.equal(expectedDiff)
     // else console.log(diff, expectedDiff)
   })
 

--- a/test/transaction-request/cancelling.js
+++ b/test/transaction-request/cancelling.js
@@ -344,16 +344,16 @@ contract("Cancelling", async (accounts) => {
 
     await waitUntilBlock(0, cancelAt)
 
-    const balanceBeforeCancel = await config.web3.eth.getBalance(accounts[1])
-    const contractBalanceBefore = await config.web3.eth.getBalance(txRequest.address)
+    // const balanceBeforeCancel = await config.web3.eth.getBalance(accounts[1])
+    // const contractBalanceBefore = await config.web3.eth.getBalance(txRequest.address)
 
     const cancelTx = await txRequest.cancel({
       from: Owner, // TODO: this throws if set to another account
     })
     expect(cancelTx.receipt).to.exist
 
-    const balanceAfterCancel = await config.web3.eth.getBalance(accounts[1])
-    const contractBalanceAfter = await config.web3.eth.getBalance(txRequest.address)
+    // const balanceAfterCancel = await config.web3.eth.getBalance(accounts[1])
+    // const contractBalanceAfter = await config.web3.eth.getBalance(txRequest.address)
 
     expect((await parseRequestData(txRequest)).meta.isCancelled).to.be.true
 

--- a/test/transaction-request/execution.js
+++ b/test/transaction-request/execution.js
@@ -112,7 +112,7 @@ contract("Execution", async (accounts) => {
     await waitUntilBlock(0, requestData.schedule.windowStart)
 
     // The min required gas is txnData.callGas + GAS_OVERHEAD (180000)
-    const gas = requestData.txData.callGas + 180000 - 5000
+    const gas = (requestData.txData.callGas + 180000) - 5000
     // console.log(gas)
     // console.log(gas + 5000)
     // TODO: Investigate this further ^^^^

--- a/test/transaction-request/executionGasRequirment.js
+++ b/test/transaction-request/executionGasRequirment.js
@@ -106,9 +106,6 @@ contract("Tests execution gas requirements", async (accounts) => {
       requestData.txData.callGas +
       (await requestLib.EXECUTION_GAS_OVERHEAD()).toNumber()
 
-    const tooLowCallGas =
-      minCallGas - (await requestLib.PRE_EXECUTION_GAS()).toNumber()
-
     const executeTx = await txRequest.execute({
       gas: minCallGas,
       gasPrice,

--- a/test/transaction-request/proxy.js
+++ b/test/transaction-request/proxy.js
@@ -11,6 +11,7 @@ const config = require("../../config")
 const ethUtil = require("ethereumjs-util")
 const { RequestData, wasAborted } = require("../dataHelpers.js")
 const { waitUntilBlock } = require("@digix/tempo")(web3)
+const simpleTokenAbi = require("./SimpleToken.json").abi
 
 contract("TransactionRequestCore proxy function", (accounts) => {
   const claimWindowSize = 25 // blocks
@@ -55,7 +56,7 @@ contract("TransactionRequestCore proxy function", (accounts) => {
     const requestData = await RequestData.from(txRequest)
 
     const duringExecutionWindow =
-      requestData.schedule.windowStart + requestData.schedule.windowSize - 2
+      (requestData.schedule.windowStart + requestData.schedule.windowSize) - 2
 
     await waitUntilBlock(0, duringExecutionWindow)
 
@@ -125,16 +126,18 @@ contract("TransactionRequestCore proxy function", (accounts) => {
     expect(executeTx.receipt).to.exist
     expect(wasAborted(executeTx)).to.be.false
 
-    expect((await tokenContract.balanceOf(txRequest.address)).toNumber()).to.equal(12345 * 30) // callValue * rate
+    const balance = (await tokenContract.balanceOf(txRequest.address)).toNumber()
+    expect(balance).to.equal(12345 * 30) // callValue * rate
 
     const afterExecutionWindow =
       requestData.schedule.windowStart + requestData.schedule.windowSize + 2
 
     await waitUntilBlock(0, afterExecutionWindow)
 
-    const t = new config.web3.eth.Contract(require("./SimpleToken.json").abi)
+    const t = new config.web3.eth.Contract(simpleTokenAbi)
     const encodedData = t.methods.transfer(accounts[8], 30000).encodeABI()
     // / This data was generated locally using the method above^^
+    /* eslint-disable max-len */
     // const encoded_data = '0xa9059cbb000000000000000000000000737b4d5a9f46839501719b5d388b7c487b55957a0000000000000000000000000000000000000000000000000000000000007530'
 
     // / NOTE the method below vv SHOULD work but generates the wrong data string for some reason

--- a/truffle.js
+++ b/truffle.js
@@ -1,11 +1,11 @@
 module.exports = {
-    networks: {
-        development: {
-            gas: 4700000,
-            gasPrice: 10000000000, // 10 gwei
-            host: "localhost",
-            port: 8545,
-            network_id: "*" // Match any network id
-        }
+  networks: {
+    development: {
+      gas: 4700000,
+      gasPrice: 10000000000, // 10 gwei
+      host: "localhost",
+      port: 8545,
+      network_id: "*" // Match any network id
     }
+  }
 };


### PR DESCRIPTION
This PR aims to bring linters to the code base to help maintain general code hygiene. 

ESLint for JS code and Solium for Solidity code. Both has been added as `pre-commit` steps and steps in TravisCI.

Solidity code changes triggered by Solium in some cases seems to be less readable than before, let's see if we want to keep it. 