### PR TITLE
Transaction events relaying through RequestFactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '8.0.0'
+  - '8'
 install:
   - npm install -g truffle
   - truffle version

--- a/contracts/Interface/RequestFactoryInterface.sol
+++ b/contracts/Interface/RequestFactoryInterface.sol
@@ -2,6 +2,11 @@ pragma solidity ^0.4.21;
 
 contract RequestFactoryInterface {
     event RequestCreated(address request, address indexed owner, int indexed bucket, uint[12] params);
+    event RequestStateChanged(address request, uint8 state);
+
+    function emitAborted() public;
+    function emitCancelled() public;
+    function emitExecuted() public;
 
     function createRequest(address[3] addressArgs, uint[12] uintArgs, bytes callData) public payable returns (address);
     function createValidatedRequest(address[3] addressArgs, uint[12] uintArgs, bytes callData) public payable returns (address);

--- a/contracts/Interface/TransactionRequestInterface.sol
+++ b/contracts/Interface/TransactionRequestInterface.sol
@@ -11,7 +11,7 @@ contract TransactionRequestInterface {
     function proxy(address recipient, bytes callData) public payable returns (bool);
 
     // Data accessors
-    function requestData() public view returns (address[6], bool[3], uint[15], uint8[1]);
+    function requestData() public view returns (address[7], bool[3], uint[15], uint8[1]);
     function callData() public view returns (bytes);
 
     // Pull mechanisms for payments.

--- a/contracts/Library/RequestMetaLib.sol
+++ b/contracts/Library/RequestMetaLib.sol
@@ -5,17 +5,12 @@ pragma solidity ^0.4.21;
  * @dev Small library holding all the metadata about a TransactionRequest.
  */
 library RequestMetaLib {
-
     struct RequestMeta {
         address owner;              /// The address that created this request.
-
         address createdBy;          /// The address of the RequestFactory which created this request.
-
         bool isCancelled;           /// Was the TransactionRequest cancelled?
-        
         bool wasCalled;             /// Was the TransactionRequest called?
-
         bool wasSuccessful;         /// Was the return value from the TransactionRequest execution successful?
+        address requestFactory;     /// Store the request factory address used to create this request
     }
-
 }

--- a/contracts/RequestFactory.sol
+++ b/contracts/RequestFactory.sol
@@ -65,7 +65,8 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
                 msg.sender,       // Created by
                 _addressArgs[0],  // meta.owner
                 _addressArgs[1],  // paymentData.feeRecipient
-                _addressArgs[2]   // txnData.toAddress
+                _addressArgs[2],  // txnData.toAddress
+                address(this)     // meta.requestFactory
             ],
             _uintArgs,            //uint[12]
             _callData
@@ -151,6 +152,30 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
 
     event ValidationError(uint8 error);
 
+    enum State {
+        Executed,
+        Cancelled,
+        Aborted
+    }
+
+    function emitExecuted()
+        public
+    {
+        emitStateChange(State.Executed);
+    }
+
+    function emitCancelled()
+        public
+    {
+        emitStateChange(State.Cancelled);
+    }
+
+    function emitAborted()
+        public
+    {
+        emitStateChange(State.Aborted);
+    }
+
     /*
      * @dev Validate the constructor arguments for either `createRequest` or `createValidatedRequest`.
      */
@@ -204,5 +229,13 @@ contract RequestFactory is RequestFactoryInterface, CloneFactory {
             revert();
         }
         return sign * int(windowStart - (windowStart % bucketSize));
+    }
+
+    function emitStateChange(State state)
+        private
+    {
+        require(isKnownRequest(msg.sender));
+
+        emit RequestStateChanged(msg.sender, uint8(state));
     }
 }

--- a/contracts/TransactionRequestCore.sol
+++ b/contracts/TransactionRequestCore.sol
@@ -16,6 +16,7 @@ contract TransactionRequestCore is TransactionRequestInterface {
      *  addressArgs[1] - meta.owner
      *  addressArgs[2] - paymentData.feeRecipient
      *  addressArgs[3] - txnData.toAddress
+     *  addressArgs[4] - meta.requestFactory
      *
      *  uintArgs[0]  - paymentData.fee
      *  uintArgs[1]  - paymentData.bounty
@@ -31,7 +32,7 @@ contract TransactionRequestCore is TransactionRequestInterface {
      *  uintArgs[11] - claimData.requiredDeposit
      */
     function initialize(
-        address[4]  addressArgs,
+        address[5]  addressArgs,
         uint[12]    uintArgs,
         bytes       callData
     )
@@ -71,7 +72,7 @@ contract TransactionRequestCore is TransactionRequestInterface {
     // Declaring this function `view`, although it creates a compiler warning, is
     // necessary to return values from it.
     function requestData()
-        public view returns (address[6], bool[3], uint[15], uint8[1])
+        public view returns (address[7], bool[3], uint[15], uint8[1])
     {
         return txnRequest.serialize();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,12 +28,27 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-            "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "requires": {
-                "mime-types": "2.1.17",
+                "mime-types": "2.1.18",
                 "negotiator": "0.6.1"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                }
             }
         },
         "acorn": {
@@ -198,9 +213,9 @@
             "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "asn1.js": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-            "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "requires": {
                 "bn.js": "4.11.8",
                 "inherits": "2.0.3",
@@ -1164,9 +1179,9 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-            "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.1",
@@ -1214,11 +1229,41 @@
             }
         },
         "bl": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
-                "readable-stream": "2.3.4"
+                "readable-stream": "2.3.6",
+                "safe-buffer": "5.1.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
             }
         },
         "block-stream": {
@@ -1248,12 +1293,12 @@
                 "content-type": "1.0.4",
                 "debug": "2.6.9",
                 "depd": "1.1.2",
-                "http-errors": "1.6.2",
+                "http-errors": "1.6.3",
                 "iconv-lite": "0.4.19",
                 "on-finished": "2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.15"
+                "type-is": "1.6.16"
             },
             "dependencies": {
                 "debug": {
@@ -1317,19 +1362,19 @@
             }
         },
         "browserify-cipher": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "requires": {
                 "browserify-aes": "1.1.1",
-                "browserify-des": "1.0.0",
+                "browserify-des": "1.0.1",
                 "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+            "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "requires": {
                 "cipher-base": "1.0.4",
                 "des.js": "1.0.0",
@@ -1371,16 +1416,16 @@
                 "create-hmac": "1.1.6",
                 "elliptic": "6.4.0",
                 "inherits": "2.0.3",
-                "parse-asn1": "5.1.0"
+                "parse-asn1": "5.1.1"
             }
         },
         "buffer": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
-            "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+            "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
             "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.8"
+                "base64-js": "1.3.0",
+                "ieee754": "1.1.11"
             }
         },
         "buffer-crc32": {
@@ -2026,9 +2071,9 @@
             }
         },
         "create-ecdh": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
+            "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
             "requires": {
                 "bn.js": "4.11.8",
                 "elliptic": "6.4.0"
@@ -2091,17 +2136,17 @@
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "requires": {
-                "browserify-cipher": "1.0.0",
+                "browserify-cipher": "1.0.1",
                 "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.0",
+                "create-ecdh": "4.0.1",
                 "create-hash": "1.1.3",
                 "create-hmac": "1.1.6",
-                "diffie-hellman": "5.0.2",
+                "diffie-hellman": "5.0.3",
                 "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.0",
+                "pbkdf2": "3.0.16",
+                "public-encrypt": "4.0.2",
                 "randombytes": "2.0.6",
-                "randomfill": "1.0.3"
+                "randomfill": "1.0.4"
             }
         },
         "crypto-js": {
@@ -2364,9 +2409,9 @@
             }
         },
         "diffie-hellman": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "requires": {
                 "bn.js": "4.11.8",
                 "miller-rabin": "4.0.1",
@@ -2933,6 +2978,11 @@
                 "strip-hex-prefix": "1.0.0"
             }
         },
+        "eventemitter3": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+            "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+        },
         "evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -2988,11 +3038,11 @@
             }
         },
         "express": {
-            "version": "4.16.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-            "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+            "version": "4.16.3",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
@@ -3004,22 +3054,22 @@
                 "encodeurl": "1.0.2",
                 "escape-html": "1.0.3",
                 "etag": "1.8.1",
-                "finalhandler": "1.1.0",
+                "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
                 "methods": "1.1.2",
                 "on-finished": "2.3.0",
                 "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.2",
+                "proxy-addr": "2.0.3",
                 "qs": "6.5.1",
                 "range-parser": "1.2.0",
                 "safe-buffer": "5.1.1",
-                "send": "0.16.1",
-                "serve-static": "1.13.1",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.3.1",
-                "type-is": "1.6.15",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
                 "utils-merge": "1.0.1",
                 "vary": "1.1.2"
             },
@@ -3032,15 +3082,10 @@
                         "ms": "2.0.0"
                     }
                 },
-                "setprototypeof": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-                },
                 "statuses": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                    "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
                 }
             }
         },
@@ -3139,16 +3184,16 @@
             }
         },
         "finalhandler": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-            "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "1.0.2",
                 "escape-html": "1.0.3",
                 "on-finished": "2.3.0",
                 "parseurl": "1.3.2",
-                "statuses": "1.3.1",
+                "statuses": "1.4.0",
                 "unpipe": "1.0.0"
             },
             "dependencies": {
@@ -3161,9 +3206,9 @@
                     }
                 },
                 "statuses": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                    "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
                 }
             }
         },
@@ -4589,21 +4634,14 @@
             "dev": true
         },
         "http-errors": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
-                "depd": "1.1.1",
+                "depd": "1.1.2",
                 "inherits": "2.0.3",
-                "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-                }
+                "setprototypeof": "1.1.0",
+                "statuses": "1.5.0"
             }
         },
         "http-https": {
@@ -4627,9 +4665,9 @@
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
         },
         "ieee754": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
         },
         "ignore": {
             "version": "3.3.7",
@@ -4778,9 +4816,9 @@
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "ipaddr.js": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-            "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+            "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -6422,15 +6460,15 @@
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "parse-asn1": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+            "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "requires": {
-                "asn1.js": "4.9.2",
+                "asn1.js": "4.10.1",
                 "browserify-aes": "1.1.1",
                 "create-hash": "1.1.3",
                 "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-glob": {
@@ -6522,9 +6560,9 @@
             "dev": true
         },
         "pbkdf2": {
-            "version": "3.0.14",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+            "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "requires": {
                 "create-hash": "1.1.3",
                 "create-hmac": "1.1.6",
@@ -6653,12 +6691,12 @@
             "dev": true
         },
         "proxy-addr": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-            "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+            "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
             "requires": {
                 "forwarded": "0.1.2",
-                "ipaddr.js": "1.5.2"
+                "ipaddr.js": "1.6.0"
             }
         },
         "prr": {
@@ -6673,14 +6711,14 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "public-encrypt": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+            "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "requires": {
                 "bn.js": "4.11.8",
                 "browserify-rsa": "4.0.1",
                 "create-hash": "1.1.3",
-                "parse-asn1": "5.1.0",
+                "parse-asn1": "5.1.1",
                 "randombytes": "2.0.6"
             }
         },
@@ -6750,9 +6788,9 @@
             }
         },
         "randomfill": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-            "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "requires": {
                 "randombytes": "2.0.6",
                 "safe-buffer": "5.1.1"
@@ -6777,6 +6815,29 @@
                 "http-errors": "1.6.2",
                 "iconv-lite": "0.4.19",
                 "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "depd": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+                },
+                "http-errors": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+                    "requires": {
+                        "depd": "1.1.1",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.0.3",
+                        "statuses": "1.5.0"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+                }
             }
         },
         "read-chunk": {
@@ -7206,7 +7267,7 @@
             "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
             "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
             "requires": {
-                "pbkdf2": "3.0.14"
+                "pbkdf2": "3.0.16"
             }
         },
         "secure-keys": {
@@ -7238,9 +7299,9 @@
             "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "send": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-            "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
             "requires": {
                 "debug": "2.6.9",
                 "depd": "1.1.2",
@@ -7249,12 +7310,12 @@
                 "escape-html": "1.0.3",
                 "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.2",
+                "http-errors": "1.6.3",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
                 "on-finished": "2.3.0",
                 "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "statuses": "1.4.0"
             },
             "dependencies": {
                 "debug": {
@@ -7266,21 +7327,21 @@
                     }
                 },
                 "statuses": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                    "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
                 }
             }
         },
         "serve-static": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-            "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "requires": {
                 "encodeurl": "1.0.2",
                 "escape-html": "1.0.3",
                 "parseurl": "1.3.2",
-                "send": "0.16.1"
+                "send": "0.16.2"
             }
         },
         "servify": {
@@ -7290,7 +7351,7 @@
             "requires": {
                 "body-parser": "1.18.2",
                 "cors": "2.8.4",
-                "express": "4.16.2",
+                "express": "4.16.3",
                 "request": "2.83.0",
                 "xhr": "2.4.1"
             }
@@ -7311,9 +7372,9 @@
             "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "setprototypeof": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-            "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "sha.js": {
             "version": "2.4.10",
@@ -7957,9 +8018,9 @@
             }
         },
         "statuses": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         },
         "stream-combiner": {
             "version": "0.0.4",
@@ -8088,7 +8149,7 @@
             "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
             "requires": {
                 "bluebird": "3.5.1",
-                "buffer": "5.0.8",
+                "buffer": "5.1.0",
                 "decompress": "4.2.0",
                 "eth-lib": "0.1.27",
                 "fs-extra": "2.1.2",
@@ -8203,17 +8264,10 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
             "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
             "requires": {
-                "bl": "1.2.1",
+                "bl": "1.2.2",
                 "end-of-stream": "1.4.1",
                 "readable-stream": "2.3.4",
                 "xtend": "4.0.1"
-            },
-            "dependencies": {
-                "xtend": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                }
             }
         },
         "tar.gz": {
@@ -8370,12 +8424,27 @@
             "dev": true
         },
         "type-is": {
-            "version": "1.6.15",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "version": "1.6.16",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.17"
+                "mime-types": "2.1.18"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                }
             }
         },
         "typedarray": {
@@ -8385,9 +8454,9 @@
             "dev": true
         },
         "typedarray-to-buffer": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-            "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
             "requires": {
                 "is-typedarray": "1.0.0"
             }
@@ -8491,7 +8560,7 @@
                     "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
                     "requires": {
                         "base64-js": "0.0.8",
-                        "ieee754": "1.1.8",
+                        "ieee754": "1.1.11",
                         "isarray": "1.0.0"
                     }
                 },
@@ -8639,23 +8708,23 @@
             }
         },
         "web3": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.29.tgz",
-            "integrity": "sha1-6Xv9X94UWlAYFyTxd3+NuRg2YmA=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
+            "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
             "requires": {
-                "web3-bzz": "1.0.0-beta.29",
-                "web3-core": "1.0.0-beta.29",
-                "web3-eth": "1.0.0-beta.29",
-                "web3-eth-personal": "1.0.0-beta.29",
-                "web3-net": "1.0.0-beta.29",
-                "web3-shh": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-bzz": "1.0.0-beta.34",
+                "web3-core": "1.0.0-beta.34",
+                "web3-eth": "1.0.0-beta.34",
+                "web3-eth-personal": "1.0.0-beta.34",
+                "web3-net": "1.0.0-beta.34",
+                "web3-shh": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-bzz": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.29.tgz",
-            "integrity": "sha1-xAVVzjKB9jf8X1yD3HsIy+70K3I=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+            "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
             "requires": {
                 "got": "7.1.0",
                 "swarm-js": "0.1.37",
@@ -8663,116 +8732,97 @@
             }
         },
         "web3-core": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.29.tgz",
-            "integrity": "sha1-G/uc3AHMPqcZDplh+PeIa7Qc/PE=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+            "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
             "requires": {
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-core-requestmanager": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-core-requestmanager": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-core-helpers": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.29.tgz",
-            "integrity": "sha1-kUJt7MEEEmI4TA3quRvXmnCLGQI=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+            "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-eth-iban": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-core-method": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.29.tgz",
-            "integrity": "sha1-11trk9FuK5yoxPcc3G/ubCk2HHY=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+            "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-promievent": "1.0.0-beta.29",
-                "web3-core-subscriptions": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-promievent": "1.0.0-beta.34",
+                "web3-core-subscriptions": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-core-promievent": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.29.tgz",
-            "integrity": "sha1-zziMs052BSiFp8K9Fec1jDm32Zg=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+            "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
             "requires": {
-                "bluebird": "3.3.1",
+                "any-promise": "1.3.0",
                 "eventemitter3": "1.1.1"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-                    "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-                },
-                "eventemitter3": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-                    "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-                }
             }
         },
         "web3-core-requestmanager": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.29.tgz",
-            "integrity": "sha1-7s36oLtNJ8SEbEaFmJr2NVqxBzw=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+            "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-providers-http": "1.0.0-beta.29",
-                "web3-providers-ipc": "1.0.0-beta.29",
-                "web3-providers-ws": "1.0.0-beta.29"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-providers-http": "1.0.0-beta.34",
+                "web3-providers-ipc": "1.0.0-beta.34",
+                "web3-providers-ws": "1.0.0-beta.34"
             }
         },
         "web3-core-subscriptions": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.29.tgz",
-            "integrity": "sha1-D5R1q0diCQC4gsrILsQr3NNbRKE=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+            "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
             "requires": {
                 "eventemitter3": "1.1.1",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-                    "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
-                }
+                "web3-core-helpers": "1.0.0-beta.34"
             }
         },
         "web3-eth": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.29.tgz",
-            "integrity": "sha1-FTovYTcM50Qc4/JK5eFSC0K5PSQ=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+            "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-core-subscriptions": "1.0.0-beta.29",
-                "web3-eth-abi": "1.0.0-beta.29",
-                "web3-eth-accounts": "1.0.0-beta.29",
-                "web3-eth-contract": "1.0.0-beta.29",
-                "web3-eth-iban": "1.0.0-beta.29",
-                "web3-eth-personal": "1.0.0-beta.29",
-                "web3-net": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-core-subscriptions": "1.0.0-beta.34",
+                "web3-eth-abi": "1.0.0-beta.34",
+                "web3-eth-accounts": "1.0.0-beta.34",
+                "web3-eth-contract": "1.0.0-beta.34",
+                "web3-eth-iban": "1.0.0-beta.34",
+                "web3-eth-personal": "1.0.0-beta.34",
+                "web3-net": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-eth-abi": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.29.tgz",
-            "integrity": "sha1-eRPArlRRAFmpjb0MubqG00IO+II=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+            "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
             "requires": {
                 "bn.js": "4.11.6",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             },
             "dependencies": {
                 "bn.js": {
@@ -8783,27 +8833,22 @@
             }
         },
         "web3-eth-accounts": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.29.tgz",
-            "integrity": "sha1-mG/z7X0XHam6egPByblLMb4vk+w=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+            "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
             "requires": {
-                "bluebird": "3.3.1",
+                "any-promise": "1.3.0",
                 "crypto-browserify": "3.12.0",
                 "eth-lib": "0.2.7",
                 "scrypt.js": "0.2.0",
                 "underscore": "1.8.3",
                 "uuid": "2.0.1",
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             },
             "dependencies": {
-                "bluebird": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-                    "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-                },
                 "eth-lib": {
                     "version": "0.2.7",
                     "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
@@ -8822,114 +8867,102 @@
             }
         },
         "web3-eth-contract": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.29.tgz",
-            "integrity": "sha1-xXTGOpCEi5gvF2tBwt76tFmMSmk=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+            "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-core-promievent": "1.0.0-beta.29",
-                "web3-core-subscriptions": "1.0.0-beta.29",
-                "web3-eth-abi": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-core-promievent": "1.0.0-beta.34",
+                "web3-core-subscriptions": "1.0.0-beta.34",
+                "web3-eth-abi": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-eth-iban": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.29.tgz",
-            "integrity": "sha1-eXSsE2X2WXdsxqv1xV4ty8Jw44E=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+            "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
             "requires": {
-                "bn.js": "4.11.8",
-                "web3-utils": "1.0.0-beta.29"
+                "bn.js": "4.11.6",
+                "web3-utils": "1.0.0-beta.34"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.6",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                }
             }
         },
         "web3-eth-personal": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.29.tgz",
-            "integrity": "sha1-qk0e+k7hR4fzcnuxw2DxLtfIqqI=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+            "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
             "requires": {
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-helpers": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-net": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-helpers": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-net": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-net": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.29.tgz",
-            "integrity": "sha1-8zYaw9o26FkB7hVh61K+5S2dS+4=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+            "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
             "requires": {
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-utils": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-providers-http": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.29.tgz",
-            "integrity": "sha1-UAFYhAnMKxj4qqwJINUuOQR+Ir0=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+            "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
             "requires": {
-                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.34",
                 "xhr2": "0.1.4"
             }
         },
         "web3-providers-ipc": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.29.tgz",
-            "integrity": "sha1-uMLaC1ql3KoqZc/tq/VXKyJV2rk=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+            "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
             "requires": {
                 "oboe": "2.1.3",
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29"
+                "web3-core-helpers": "1.0.0-beta.34"
             }
         },
         "web3-providers-ws": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.29.tgz",
-            "integrity": "sha1-LtnZsoj2IZs3+gV8XlsM/t3NAbs=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+            "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.29",
+                "web3-core-helpers": "1.0.0-beta.34",
                 "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "websocket": {
-                    "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-                    "requires": {
-                        "debug": "2.6.9",
-                        "nan": "2.8.0",
-                        "typedarray-to-buffer": "3.1.2",
-                        "yaeti": "0.0.6"
-                    }
-                }
             }
         },
         "web3-shh": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.29.tgz",
-            "integrity": "sha1-HnA1Utrpa/Z7Y+RoNRSxRV+aWEY=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+            "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
             "requires": {
-                "web3-core": "1.0.0-beta.29",
-                "web3-core-method": "1.0.0-beta.29",
-                "web3-core-subscriptions": "1.0.0-beta.29",
-                "web3-net": "1.0.0-beta.29"
+                "web3-core": "1.0.0-beta.34",
+                "web3-core-method": "1.0.0-beta.34",
+                "web3-core-subscriptions": "1.0.0-beta.34",
+                "web3-net": "1.0.0-beta.34"
             }
         },
         "web3-utils": {
-            "version": "1.0.0-beta.29",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.29.tgz",
-            "integrity": "sha1-iZkl7RWyDV9wgU34o1Ji5Nb8pqk=",
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+            "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
             "requires": {
                 "bn.js": "4.11.6",
                 "eth-lib": "0.1.27",
@@ -9259,6 +9292,25 @@
                 }
             }
         },
+        "websocket": {
+            "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+            "requires": {
+                "debug": "2.6.9",
+                "nan": "2.8.0",
+                "typedarray-to-buffer": "3.1.5",
+                "yaeti": "0.0.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "which": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -9336,13 +9388,6 @@
                 "is-function": "1.0.1",
                 "parse-headers": "2.0.1",
                 "xtend": "4.0.1"
-            },
-            "dependencies": {
-                "xtend": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-                }
             }
         },
         "xhr-request": {
@@ -9381,8 +9426,7 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "y18n": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "nconf": "^0.8.4",
         "solc": "^0.4.21",
         "solium": "^1.1.6",
-        "web3": "^1.0.0-beta.18"
+        "web3": "1.0.0-beta.34"
     },
     "devDependencies": {
         "@digix/tempo": "^0.2.0",

--- a/test/dataHelpers.js
+++ b/test/dataHelpers.js
@@ -60,6 +60,7 @@ const parseRequestData = async (transactionRequest) => {
       isCancelled: data[1][0],
       wasCalled: data[1][1],
       wasSuccessful: data[1][2],
+      requestFactory: data[0][6]
     },
 
     paymentData: {
@@ -109,6 +110,7 @@ class RequestData {
       isCancelled: data[1][0],
       wasCalled: data[1][1],
       wasSuccessful: data[1][2],
+      requestFactory: data[0][6]
     }
 
     this.paymentData = {
@@ -159,6 +161,7 @@ class RequestData {
       isCancelled: data[1][0],
       wasCalled: data[1][1],
       wasSuccessful: data[1][2],
+      requestFactory: data[0][6]
     }
 
     this.paymentData = {

--- a/test/integration/scheduleToExecute.js
+++ b/test/integration/scheduleToExecute.js
@@ -100,6 +100,8 @@ contract("Schedule to execution flow", (accounts) => {
     expect(requestData.paymentData.fee).to.equal(98765)
 
     expect(requestData.paymentData.bounty).to.equal(80008)
+
+    expect(requestData.meta.requestFactory).to.equal(requestFactory.address)
   })
 
   it("should claim from an account", async () => {
@@ -123,6 +125,15 @@ contract("Schedule to execution flow", (accounts) => {
     })
 
     expect(executeTx.receipt).to.exist
+
+    const events = await new Promise(resolve => requestFactory.RequestStateChanged({})
+      .get((err, e) => resolve(e)))
+
+    const requestStateChanged = events[0]
+
+    expect(requestStateChanged).to.exist
+    expect(requestStateChanged.args.request).to.equal(txRequest.address)
+    expect(requestStateChanged.args.state.toNumber()).to.equal(0) // 0 is executed
 
     await requestData.refresh()
 


### PR DESCRIPTION
Events emitted by TransactionRequest contracts are now relayed and emitted by RequestFactory. `RequestStateChange(address transactionRequest, uint8 state)` event is now part of RequestFactory, possible states are:
```
enum State {
        Executed,
        Cancelled,
        Aborted
    }
```

This aim to simply interactions between DApps and EAC. Use cases that can be now created based on events only are:
* building a list of scheduled transactions
* building a list of executed transactions  

General flow for building lists is:
* get all (or for given bucket) RequestCreated events - as they provide most of the data
* get all RequestStateChange events
* join the events to produce the final state

This is complementary PR to #125.