### PR TITLE
[BUGFIX] Fix test suite.

### DIFF
--- a/test/transaction-request/proxy.js
+++ b/test/transaction-request/proxy.js
@@ -77,7 +77,7 @@ contract("TransactionRequestCore proxy function", (accounts) => {
 
     // This is allowed since it is from scheduling accounts
     const tx = await txRequest.proxy(accounts[7], testData32)
-    expect(tx.receipt.status).to.be.oneOf(['0x01', 1])
+    expect(tx.receipt.status).to.be.oneOf(['0x1', '0x01', 1])
   })
 
   it("does some fancy stuff with proxy", async () => {


### PR DESCRIPTION
Seems like `0x1` is now one of possible options to receive as transaction status.

Link to failed build on master:
https://travis-ci.org/ethereum-alarm-clock/ethereum-alarm-clock/builds/393369347#L844